### PR TITLE
Discord rich presence feature implementation

### DIFF
--- a/muzik-offline/src-tauri/.gitignore
+++ b/muzik-offline/src-tauri/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 .VSCodeCounter/
 /db/
+.env

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -521,7 +521,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -958,6 +958,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47fc4beffb85ee1461588499073a4d9c20dcc7728c4b13d6b282ab6c508947e5"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2305,6 +2317,7 @@ version = "0.2.1"
 dependencies = [
  "base64 0.21.5",
  "dirs",
+ "discord-rich-presence",
  "id3",
  "image",
  "kira",
@@ -3928,7 +3941,7 @@ dependencies = [
  "serde",
  "tao-macros",
  "unicode-segmentation",
- "uuid",
+ "uuid 1.6.1",
  "windows 0.39.0",
  "windows-implement",
  "x11-dl",
@@ -4007,7 +4020,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
- "uuid",
+ "uuid 1.6.1",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
@@ -4054,7 +4067,7 @@ dependencies = [
  "tauri-utils",
  "thiserror",
  "time",
- "uuid",
+ "uuid 1.6.1",
  "walkdir",
 ]
 
@@ -4088,7 +4101,7 @@ dependencies = [
  "tauri-utils",
  "thiserror",
  "url",
- "uuid",
+ "uuid 1.6.1",
  "webview2-com",
  "windows 0.39.0",
 ]
@@ -4106,7 +4119,7 @@ dependencies = [
  "raw-window-handle",
  "tauri-runtime",
  "tauri-utils",
- "uuid",
+ "uuid 1.6.1",
  "webkit2gtk",
  "webview2-com",
  "windows 0.39.0",
@@ -4507,6 +4520,15 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.11",
+]
 
 [[package]]
 name = "uuid"

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -979,6 +979,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2324,7 @@ dependencies = [
  "base64 0.21.5",
  "dirs",
  "discord-rich-presence",
+ "dotenv",
  "id3",
  "image",
  "kira",

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ rand = "0.8.5"
 rayon = "1.8.0"
 sled = "0.34.7"
 dirs = "5.0.1"
+discord-rich-presence = "0.2.3"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ rayon = "1.8.0"
 sled = "0.34.7"
 dirs = "5.0.1"
 discord-rich-presence = "0.2.3"
+dotenv = "0.15.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "path-all", "dialog-open", "notification-all", "os-all", "window-set-resizable", "window-set-fullscreen", "shell-open"] }
+tauri = { version = "1.5", features = [ "window-start-dragging", "window-minimize", "window-close", "window-show", "window-unmaximize", "window-unminimize", "window-hide", "window-maximize", "path-all", "dialog-open", "notification-all", "os-all", "window-set-resizable", "window-set-fullscreen", "shell-open"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 id3 = "1.10.0"

--- a/muzik-offline/src-tauri/src/main.rs
+++ b/muzik-offline/src-tauri/src/main.rs
@@ -30,15 +30,8 @@ use crate::socials::discord_rpc::{allow_connection_and_connect_to_discord_rpc,
     attempt_to_connect_if_possible, disallow_connection_and_close_discord_rpc,
     set_discord_rpc_activity, clear_discord_rpc_activity};
 
-use dotenv::dotenv;
-
 fn main() {
     tauri::Builder::default()
-        .setup(|_| {
-            //init env variables
-            dotenv().ok();
-            Ok(())
-        })
         .manage(Mutex::new(SharedAudioManager {
             //this expect is necessary because if the audio manager fails to initialize, the application should not run
             //since we would not be able to play any audio if it fails to initialize

--- a/muzik-offline/src-tauri/src/main.rs
+++ b/muzik-offline/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ mod socials;
 use kira::manager::{AudioManager,AudioManagerSettings,backend::DefaultBackend};
 use components::audio_manager::SharedAudioManager;
 use utils::music_list_organizer::MLO;
+use crate::socials::discord_rpc::DiscordRpc;
 use std::sync::Mutex;
 
 use crate::commands::metadata_retriever::get_all_songs;
@@ -25,8 +26,19 @@ use crate::utils::music_list_organizer::{mlo_set_shuffle_list, mlo_set_repeat_li
 
 use crate::database::db_api::{get_batch_of_songs, get_batch_of_albums, get_batch_of_artists, get_batch_of_genres,};
 
+use crate::socials::discord_rpc::{allow_connection_and_connect_to_discord_rpc,
+    attempt_to_connect_if_possible, disallow_connection_and_close_discord_rpc,
+    set_discord_rpc_activity, clear_discord_rpc_activity};
+
+use dotenv::dotenv;
+
 fn main() {
     tauri::Builder::default()
+        .setup(|_| {
+            //init env variables
+            dotenv().ok();
+            Ok(())
+        })
         .manage(Mutex::new(SharedAudioManager {
             //this expect is necessary because if the audio manager fails to initialize, the application should not run
             //since we would not be able to play any audio if it fails to initialize
@@ -34,10 +46,14 @@ fn main() {
             instance_handle: None,
         }))
         .manage(Mutex::new(MLO::new()))
+        .manage(Mutex::new(DiscordRpc::new().expect("failed to initialize discord rpc")))
         .invoke_handler(tauri::generate_handler![
+                            //GENERAL COMMANDS
                             get_all_songs, 
                             open_in_file_manager,
                             set_volume,
+
+                            //MUSIC PLAYER
                             load_and_play_song_from_path,
                             load_a_song_from_path,
                             pause_song,
@@ -45,15 +61,28 @@ fn main() {
                             stop_song,
                             seek_to,
                             get_song_position,
+
+                            //UTILS
                             resize_frontend_image_to_fixed_height,
+
+                            //MUSIC LIST ORGANIZER
                             mlo_set_shuffle_list,
                             mlo_set_repeat_list,
                             mlo_reset_and_set_remaining_keys,
                             mlo_get_next_batch_as_size,
+
+                            //DATABASE API
                             get_batch_of_songs, 
                             get_batch_of_albums, 
                             get_batch_of_artists, 
                             get_batch_of_genres,
+
+                            //DISCORD RPC
+                            allow_connection_and_connect_to_discord_rpc,
+                            attempt_to_connect_if_possible, 
+                            disallow_connection_and_close_discord_rpc,
+                            set_discord_rpc_activity, 
+                            clear_discord_rpc_activity
                         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/muzik-offline/src-tauri/src/main.rs
+++ b/muzik-offline/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod music;
 mod components;
 mod utils;
 mod database;
+mod socials;
 
 use kira::manager::{AudioManager,AudioManagerSettings,backend::DefaultBackend};
 use components::audio_manager::SharedAudioManager;

--- a/muzik-offline/src-tauri/src/socials/discord_rpc.rs
+++ b/muzik-offline/src-tauri/src/socials/discord_rpc.rs
@@ -1,30 +1,39 @@
+use tauri::State;
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use std::env;
+use std::sync::Mutex;
 
 pub struct DiscordRpc {
-    client_id: String,
     client: DiscordIpcClient,
     allowed_to_connect: bool,
 }
 
 impl DiscordRpc {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        let client_id = String::from("1197657294490583071");
+        //get client id from env variables
+        let client_id = env::var("DISCORD_CLIENT_ID").expect("DISCORD_CLIENT_ID env variable not set");
         let client: DiscordIpcClient = DiscordIpcClient::new(&client_id)?;
 
         Ok(
             Self {
-                client_id,
                 client,
                 allowed_to_connect: false,
             }
         )
     }
 
+    pub fn set_allowed_to_connect(&mut self, allowed_to_connect: bool) {
+        self.allowed_to_connect = allowed_to_connect;
+    }
+
     pub fn connect(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if self.allowed_to_connect {
             self.client.connect()?;
+            Ok(())
         }
-        Ok(())
+        else{
+            Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "not allowed to connect to discord rpc")))
+        }
     }
 
     pub fn set_activity(&mut self, song_name: String, state: String, large_image_key: String) -> Result<(), Box<dyn std::error::Error>> {
@@ -38,21 +47,151 @@ impl DiscordRpc {
                         .large_text(&song_name)
                 );
             self.client.set_activity(activity)?;
+            Ok(())
         }
-        Ok(())
+        else{
+            Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "not allowed to connect to discord rpc")))
+        }
     }
 
     pub fn clear_activity(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if self.allowed_to_connect {
             self.client.clear_activity()?;
+            Ok(())
         }
-        Ok(())
+        else{
+            Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "not allowed to connect to discord rpc")))
+        }
     }
 
     pub fn close(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         if self.allowed_to_connect {
             self.client.close()?;
+            Ok(())
         }
-        Ok(())
+        else{
+            Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "not allowed to connect to discord rpc")))
+        }
+    }
+}
+
+impl Drop for DiscordRpc {
+    fn drop(&mut self) {
+        //fail silently and print out failure but don't crash the application
+        //the OS will handle memory cleanup since the application is returning the resources it had allocated anyways
+        if self.allowed_to_connect {
+            match self.client.close(){
+                Ok(_) => {},
+                Err(e) => {
+                    println!("error while closing discord rpc: {}", e);
+                }
+            }
+        }
+    }
+}
+
+#[tauri::command]//this will run when the user sets discord rpc to enabled
+pub fn allow_connection_and_connect_to_discord_rpc(discord_rpc: State<Mutex<DiscordRpc>>) -> Result<String, String> {
+    match discord_rpc.lock(){
+        Ok(mut discord_rpc) => {
+            discord_rpc.set_allowed_to_connect(true);
+            match discord_rpc.connect(){
+                Ok(_) => {
+                    Ok(String::from("connected to discord rpc"))
+                },
+                Err(e) => {
+                    Err(format!("error while connecting to discord rpc: {}", e))
+                }
+            }
+        },
+        Err(e) => {
+            Err(format!("error while locking discord rpc mutex: {}", e))
+        }
+    }
+}
+
+#[tauri::command]//this will only ever run once when the application starts
+pub fn attempt_to_connect_if_possible(discord_rpc: State<Mutex<DiscordRpc>>) -> Result<String, String> {
+    match discord_rpc.lock(){
+        Ok(mut discord_rpc) => {
+            match discord_rpc.connect(){
+                Ok(_) => {
+                    Ok(String::from("connected to discord rpc"))
+                },
+                Err(e) => {
+                    Err(format!("error while connecting to discord rpc: {}", e))
+                }
+            }
+        },
+        Err(e) => {
+            Err(format!("error while locking discord rpc mutex: {}", e))
+        }
+    }
+}
+
+#[tauri::command]//this will run when the user sets discord rpc to disabled
+pub fn disallow_connection_and_close_discord_rpc(discord_rpc: State<Mutex<DiscordRpc>>) -> Result<String, String> {
+    match discord_rpc.lock(){
+        Ok(mut discord_rpc) => {
+            match discord_rpc.close(){
+                Ok(_) => {
+                    discord_rpc.set_allowed_to_connect(false);
+                    Ok(String::from("closed discord rpc"))
+                },
+                Err(e) => {
+                    Err(format!("error while closing discord rpc: {}", e))
+                }
+            }
+        },
+        Err(e) => {
+            Err(format!("error while locking discord rpc mutex: {}", e))
+        }
+    }
+}
+
+#[tauri::command]//this will run when the user changes the song they are listening to
+pub fn set_discord_rpc_activity(discord_rpc: State<Mutex<DiscordRpc>>, song_name: String, state: String, large_image_key: String) -> Result<String, String> {
+    match discord_rpc.lock(){
+        Ok(mut discord_rpc) => {
+            match discord_rpc.clear_activity(){
+                Ok(_) => {
+                    
+                },
+                Err(e) => {
+                    return Err(format!("error while clearing discord rpc activity: {}", e));
+                }
+            }
+
+            match discord_rpc.set_activity(song_name, state, large_image_key){
+                Ok(_) => {
+                    Ok(String::from("set discord rpc activity"))
+                },
+                Err(e) => {
+                    Err(format!("error while setting discord rpc activity: {}", e))
+                }
+            }
+        },
+        Err(e) => {
+            Err(format!("error while locking discord rpc mutex: {}", e))
+        }
+    }
+}
+
+#[tauri::command]//this will run just before the user changes the song they are listening to or when they stop listening to music
+pub fn clear_discord_rpc_activity(discord_rpc: State<Mutex<DiscordRpc>>) -> Result<String, String> {
+    match discord_rpc.lock(){
+        Ok(mut discord_rpc) => {
+            match discord_rpc.clear_activity(){
+                Ok(_) => {
+                    Ok(String::from("cleared discord rpc activity"))
+                },
+                Err(e) => {
+                    Err(format!("error while clearing discord rpc activity: {}", e))
+                }
+            }
+        },
+        Err(e) => {
+            Err(format!("error while locking discord rpc mutex: {}", e))
+        }
     }
 }

--- a/muzik-offline/src-tauri/src/socials/discord_rpc.rs
+++ b/muzik-offline/src-tauri/src/socials/discord_rpc.rs
@@ -1,0 +1,58 @@
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+
+pub struct DiscordRpc {
+    client_id: String,
+    client: DiscordIpcClient,
+    allowed_to_connect: bool,
+}
+
+impl DiscordRpc {
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let client_id = String::from("1197657294490583071");
+        let client: DiscordIpcClient = DiscordIpcClient::new(&client_id)?;
+
+        Ok(
+            Self {
+                client_id,
+                client,
+                allowed_to_connect: false,
+            }
+        )
+    }
+
+    pub fn connect(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.allowed_to_connect {
+            self.client.connect()?;
+        }
+        Ok(())
+    }
+
+    pub fn set_activity(&mut self, song_name: String, state: String, large_image_key: String) -> Result<(), Box<dyn std::error::Error>> {
+        if self.allowed_to_connect {
+            let activity = activity::Activity::new()
+                .state(&state)
+                .details(&song_name)
+                .assets(
+                    activity::Assets::new()
+                        .large_image(&large_image_key)
+                        .large_text(&song_name)
+                );
+            self.client.set_activity(activity)?;
+        }
+        Ok(())
+    }
+
+    pub fn clear_activity(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.allowed_to_connect {
+            self.client.clear_activity()?;
+        }
+        Ok(())
+    }
+
+    pub fn close(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if self.allowed_to_connect {
+            self.client.close()?;
+        }
+        Ok(())
+    }
+}

--- a/muzik-offline/src-tauri/src/socials/discord_rpc.rs
+++ b/muzik-offline/src-tauri/src/socials/discord_rpc.rs
@@ -1,5 +1,6 @@
 use tauri::State;
 use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use dotenv::dotenv;
 use std::env;
 use std::sync::Mutex;
 
@@ -12,6 +13,7 @@ pub struct DiscordRpc {
 impl DiscordRpc {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
         //get client id from env variables
+        dotenv().ok();
         let client_id = env::var("DISCORD_CLIENT_ID").expect("DISCORD_CLIENT_ID env variable not set");
         let client: DiscordIpcClient = DiscordIpcClient::new(&client_id)?;
 

--- a/muzik-offline/src-tauri/src/socials/mod.rs
+++ b/muzik-offline/src-tauri/src/socials/mod.rs
@@ -1,0 +1,1 @@
+pub mod discord_rpc;

--- a/muzik-offline/src/interface/App/App.tsx
+++ b/muzik-offline/src/interface/App/App.tsx
@@ -4,6 +4,7 @@ import { AllGenres, AllPlaylists, AllTracks, Settings, AlbumDetails,
   AllAlbums, AllArtists, SearchPage, ArtistCatalogue, GenreView, PlaylistView } from "@pages/index";
 import { useEffect, useState } from "react";
 import { type } from '@tauri-apps/api/os';
+import { invoke } from "@tauri-apps/api";
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import { HistoryNextFloating } from "@layouts/index";
 import { OSTYPEenum } from "@muziktypes/index";
@@ -41,9 +42,16 @@ const App = () => {
     if(!permissionGranted)await requestPermission();
   }
 
+  async function connect_to_discord(){ 
+    if(local_store.AppActivityDiscord === "Yes"){
+      await invoke("allow_connection_and_connect_to_discord_rpc"); 
+    }
+  }
+
   useEffect(() => {
     checkOSType();
     checkAndRequestNotificationPermission();
+    connect_to_discord();
   }, [])
 
   return (

--- a/muzik-offline/src/interface/App/App.tsx
+++ b/muzik-offline/src/interface/App/App.tsx
@@ -7,9 +7,9 @@ import { type } from '@tauri-apps/api/os';
 import { invoke } from "@tauri-apps/api";
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import { HistoryNextFloating } from "@layouts/index";
-import { OSTYPEenum } from "@muziktypes/index";
+import { OSTYPEenum, toastType } from "@muziktypes/index";
 import { AnimatePresence } from "framer-motion";
-import { useWallpaperStore, useSavedObjectStore } from "store";
+import { useWallpaperStore, useSavedObjectStore, useToastStore } from "store";
 import { SavedObject } from "@database/saved_object";
 import { isPermissionGranted, requestPermission } from '@tauri-apps/api/notification';
 
@@ -19,6 +19,7 @@ const App = () => {
   const [FloatingHNState, setFloatingHNState] = useState<boolean>(false);
   const {local_store, setStore} = useSavedObjectStore((state) => { return { local_store: state.local_store, setStore: state.setStore}; });
   const { wallpaper } = useWallpaperStore((state) => { return { wallpaper: state.wallpaper,}; });
+  const { setToast } = useToastStore((state) => { return { setToast: state.setToast }; });
 
   function closeSetting(){if(openSettings === true)setOpenSettings(false);}
 
@@ -42,9 +43,13 @@ const App = () => {
     if(!permissionGranted)await requestPermission();
   }
 
-  async function connect_to_discord(){ 
+  function connect_to_discord(){ 
     if(local_store.AppActivityDiscord === "Yes"){
-      await invoke("allow_connection_and_connect_to_discord_rpc"); 
+      invoke("allow_connection_and_connect_to_discord_rpc").then().catch((_) => {
+        setToast({
+          title: "Discord connection...", message: "Failed to establish connection with discord", type: toastType.error, timeout: 5000
+        });
+      }); 
     }
   }
 

--- a/muzik-offline/src/interface/components/modals/DirectoriesModal.tsx
+++ b/muzik-offline/src/interface/components/modals/DirectoriesModal.tsx
@@ -16,8 +16,6 @@ type DirectoriesModalProps = {
     closeModal: () => void;
 }
 
-
-
 const DirectoriesModal: FunctionComponent<DirectoriesModalProps> = (props: DirectoriesModalProps) => {
     const { dir, setDir } = useDirStore((state) => { return { dir: state.dir, setDir: state.setDir}; });
     const [directories, setDirectories] = useState<string[]>(dir.Dir);

--- a/muzik-offline/src/interface/layouts/GeneralSettings.tsx
+++ b/muzik-offline/src/interface/layouts/GeneralSettings.tsx
@@ -6,6 +6,7 @@ import { selectedGeneralSettingEnum } from "@muziktypes/index";
 import { FunctionComponent, useState } from "react";
 import { DropDownMenuLarge, RadioComponent } from "@components/index";
 import { useSavedObjectStore, useViewableSideElStore } from "@store/index";
+import { invoke } from "@tauri-apps/api";
 
 const settings_data: {
     key: number;
@@ -47,11 +48,23 @@ const GeneralSettings: FunctionComponent<GeneralSettingsProps> = (props: General
         else setselectedGeneralSetting(arg);
     }
 
-    function setStoreValue(arg: string, type: string){
+    async function setStoreValue(arg: string, type: string){
+        await handleDiscordConnectionChanges(arg, type, local_store.AppActivityDiscord);
         let temp: SavedObject = local_store;
         temp[type as keyof SavedObject] = arg as never;
         setStore(temp);
         setselectedGeneralSetting(selectedGeneralSettingEnum.Nothing);
+    }
+
+    async function handleDiscordConnectionChanges(arg: string, type: string, oldarg: string){
+        if(type === "AppActivityDiscord"){
+            if(arg === "Yes" && oldarg === "No"){//connect
+                await invoke("allow_connection_and_connect_to_discord_rpc"); 
+            }
+            else if(arg === "No" && oldarg === "Yes"){//disconnect
+                await invoke("disallow_connection_and_close_discord_rpc");
+            }
+        }
     }
 
     function setViewableEl(value: boolean, type: string){

--- a/muzik-offline/src/utils/playerControl.ts
+++ b/muzik-offline/src/utils/playerControl.ts
@@ -92,7 +92,7 @@ export async function startPlayingNewSong(song: Song){
     const volume = (useSavedObjectStore.getState().local_store.Volume / 100);
     await invoke("load_and_play_song_from_path", { soundPath: song.path, volume: volume });
     usePlayerStore.getState().setPlayer(temp);
-    await setDiscordActivity(song.name);
+    setDiscordActivity(song.name);
 }
 
 export async function loadNewSong(song: Song){
@@ -103,7 +103,7 @@ export async function loadNewSong(song: Song){
     const volume = (useSavedObjectStore.getState().local_store.Volume / 100);
     await invoke("load_a_song_from_path", { soundPath: song.path, volume: volume });
     usePlayerStore.getState().setPlayer(temp);
-    await setDiscordActivity(song.name);
+    setDiscordActivity(song.name);
 }
 
 export async function playSong(){
@@ -129,7 +129,7 @@ export async function pauseSong(){
 export async function stopSong(){
     if(usePlayerStore.getState().Player.playingSongMetadata){
         await invoke("stop_song");
-        await setDiscordActivity(null);
+        setDiscordActivity(null);
         let temp = usePlayerStore.getState().Player;
         temp.playingSongMetadata = null;
         temp.lengthOfSongInSeconds = 0;
@@ -300,14 +300,12 @@ export async function playSongsFromThisArtist(shuffle: boolean, artist_name: str
     if(songkeys.length >= 2)playThisListNow(songkeys.slice(1), shuffle);
 }
 
-async function setDiscordActivity(song_name: string | null){
-    const discordConnectStatus = useSavedObjectStore().local_store.AppActivityDiscord;
+function setDiscordActivity(song_name: string | null){
+    const discordConnectStatus = useSavedObjectStore.getState().local_store.AppActivityDiscord;
     if(discordConnectStatus === "No")return;
 
     if(song_name !== null){
-        await invoke("set_discord_rpc_activity", {songName: song_name, userState: "Listening to music", largeImageKey: ""});
+        invoke("set_discord_rpc_activity", {songName: song_name, userState: "Listening to music", largeImageKey: "app_icon1024x1024"}).then().catch();
     }
-    else{
-        await invoke("clear_discord_rpc_activity");
-    }
+    else invoke("clear_discord_rpc_activity").then().catch();
 }

--- a/muzik-offline/src/utils/playerControl.ts
+++ b/muzik-offline/src/utils/playerControl.ts
@@ -92,6 +92,7 @@ export async function startPlayingNewSong(song: Song){
     const volume = (useSavedObjectStore.getState().local_store.Volume / 100);
     await invoke("load_and_play_song_from_path", { soundPath: song.path, volume: volume });
     usePlayerStore.getState().setPlayer(temp);
+    await setDiscordActivity(song.name);
 }
 
 export async function loadNewSong(song: Song){
@@ -102,6 +103,7 @@ export async function loadNewSong(song: Song){
     const volume = (useSavedObjectStore.getState().local_store.Volume / 100);
     await invoke("load_a_song_from_path", { soundPath: song.path, volume: volume });
     usePlayerStore.getState().setPlayer(temp);
+    await setDiscordActivity(song.name);
 }
 
 export async function playSong(){
@@ -127,6 +129,7 @@ export async function pauseSong(){
 export async function stopSong(){
     if(usePlayerStore.getState().Player.playingSongMetadata){
         await invoke("stop_song");
+        await setDiscordActivity(null);
         let temp = usePlayerStore.getState().Player;
         temp.playingSongMetadata = null;
         temp.lengthOfSongInSeconds = 0;
@@ -295,4 +298,16 @@ export async function playSongsFromThisArtist(shuffle: boolean, artist_name: str
         if(song !== undefined)startPlayingNewSong(song);
     }
     if(songkeys.length >= 2)playThisListNow(songkeys.slice(1), shuffle);
+}
+
+async function setDiscordActivity(song_name: string | null){
+    const discordConnectStatus = useSavedObjectStore().local_store.AppActivityDiscord;
+    if(discordConnectStatus === "No")return;
+
+    if(song_name !== null){
+        await invoke("set_discord_rpc_activity", {songName: song_name, userState: "Listening to music", largeImageKey: ""});
+    }
+    else{
+        await invoke("clear_discord_rpc_activity");
+    }
 }


### PR DESCRIPTION
# Implementation of discord rich presence:
1. I made use of the discord-rich-presence <a href="https://crates.io/crates/discord-rich-presence">crate</a> using version ```0.2.3```
2. All of the code for the RPC API is found in <a href="https://github.com/muzik-apps/muzik-offline/blob/discord-rich-presence/muzik-offline/src-tauri/src/socials/discord_rpc.rs">discord_rpc</a> which acts as an API wrapper and only exposes certain functions that will be needed by the frontend, namely:
```
allow_connection_and_connect_to_discord_rpc,
attempt_to_connect_if_possible, 
disallow_connection_and_close_discord_rpc,
set_discord_rpc_activity, 
clear_discord_rpc_activity
```
3. The functionality of discord rpc has been tested and shows that it is stable and works well enough. 
4. A dotenv crate was also added to store the client_id for discord in dev environments without uploading it to github, however when a production build is made, the client_id can just be embedded in the source code if building with an env variable fails.

***A production build is yet to be tested but will be tested before this pr is merged with <a href="https://github.com/muzik-apps/muzik-offline/tree/main-app-dev">main-app-dev</a>***