### PR TITLE
Making seeker easier to use

### DIFF
--- a/muzik-offline/src-tauri/src/commands/metadata_retriever.rs
+++ b/muzik-offline/src-tauri/src/commands/metadata_retriever.rs
@@ -248,7 +248,7 @@ fn set_duration_bit_rate_sample_rate_bit_depth_channels(path: &str, song_meta_da
 
 fn set_path(path: &str, song_meta_data: &mut Song){
     //PATH
-    song_meta_data.path = path.clone().to_owned();
+    song_meta_data.path = path.to_owned();
 }
 
 fn set_cover(tag: &Tag, song_meta_data: &mut Song, compress_image_option: &bool){

--- a/muzik-offline/src-tauri/src/components/audio_manager.rs
+++ b/muzik-offline/src-tauri/src/components/audio_manager.rs
@@ -3,4 +3,5 @@ use kira::{manager::{AudioManager, backend::DefaultBackend}, sound::{streaming::
 pub struct SharedAudioManager {
     pub manager: AudioManager<DefaultBackend>,
     pub instance_handle: Option<StreamingSoundHandle<FromFileError>>,
+    pub volume: f64,
 }

--- a/muzik-offline/src-tauri/src/main.rs
+++ b/muzik-offline/src-tauri/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
             //since we would not be able to play any audio if it fails to initialize
             manager: AudioManager::<DefaultBackend>::new(AudioManagerSettings::default()).expect("failed to initialize audio manager"),
             instance_handle: None,
+            volume: 0.0,
         }))
         .manage(Mutex::new(MLO::new()))
         .invoke_handler(tauri::generate_handler![

--- a/muzik-offline/src-tauri/src/main.rs
+++ b/muzik-offline/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use crate::commands::metadata_retriever::get_all_songs;
 use crate::commands::general_commands::{open_in_file_manager, resize_frontend_image_to_fixed_height};
 
 use crate::music::player::{load_and_play_song_from_path, load_a_song_from_path, set_volume,
-    pause_song, resume_playing, seek_to, get_song_position, stop_song};
+    pause_song, resume_playing, seek_to, seek_by, get_song_position, stop_song};
 
 use crate::utils::music_list_organizer::{mlo_set_shuffle_list, mlo_set_repeat_list, 
     mlo_get_next_batch_as_size, mlo_reset_and_set_remaining_keys};
@@ -44,6 +44,7 @@ fn main() {
                             resume_playing,
                             stop_song,
                             seek_to,
+                            seek_by,
                             get_song_position,
                             resize_frontend_image_to_fixed_height,
                             mlo_set_shuffle_list,

--- a/muzik-offline/src-tauri/src/music/player.rs
+++ b/muzik-offline/src-tauri/src/music/player.rs
@@ -253,6 +253,31 @@ pub fn seek_to(audio_manager: State<'_, Mutex<SharedAudioManager>>, position: f6
 }
 
 #[tauri::command]
+pub fn seek_by(audio_manager: State<'_, Mutex<SharedAudioManager>>, delta: f64){
+    match audio_manager.lock(){
+        Ok(mut manager) => {
+            match &mut manager.instance_handle{
+                Some(handle) => {
+                    match handle.seek_by(delta){
+                        Ok(_) => {
+                        },
+                        Err(_) => {
+                            //failed to seek by delta
+                        },
+                    }
+                },
+                None => {
+                    //no song is currently paused or playing
+                },
+            }
+        },
+        Err(_) => {
+            //failed to lock audio manager
+        },
+    }
+}
+
+#[tauri::command]
 pub fn get_song_position(audio_manager: State<'_, Mutex<SharedAudioManager>>) -> f64{
     match audio_manager.lock(){
         Ok(mut manager) => {
@@ -317,7 +342,7 @@ fn handle_true_seeking(handle: &mut StreamingSoundHandle<FromFileError>, volume:
     //the only way around this would be to figure out how to clear the audio data from memory
     //or how long the audio data that we want to skip past is and just allow the song to play for that long
     //before pausing it again whilst the volume is 0.0. Hopefully the user won't notice this because
-    //that delay may get as large as 200ms or so depending on the size of the audio data that was loaded into memory
+    //that delay may get as large as 300ms or so depending on the size of the audio data that was loaded into memory
 
     match handle.set_volume(0.0, Tween::default()){
         Ok(_) => {
@@ -332,7 +357,7 @@ fn handle_true_seeking(handle: &mut StreamingSoundHandle<FromFileError>, volume:
         Ok(_) => {
             //resumed song
             //pause the song after a short delay
-            std::thread::sleep(std::time::Duration::from_millis(200));
+            std::thread::sleep(std::time::Duration::from_millis(270));
             match handle.pause(Tween::default()){
                 Ok(_) => {
                     //paused song

--- a/muzik-offline/src-tauri/src/music/player.rs
+++ b/muzik-offline/src-tauri/src/music/player.rs
@@ -1,6 +1,6 @@
 use tauri::State;
 use kira::{
-	sound::streaming::{StreamingSoundData, StreamingSoundSettings}, tween::Tween
+	sound::{streaming::{StreamingSoundData, StreamingSoundSettings, StreamingSoundHandle}, FromFileError}, tween::Tween
 };
 use std::sync::Mutex;
 use crate::components::audio_manager::SharedAudioManager;
@@ -39,6 +39,7 @@ pub fn load_and_play_song_from_path(audio_manager: State<'_, Mutex<SharedAudioMa
                                     match handle.set_volume(volume, Tween::default()){
                                         Ok(_) => {
                                             //set volume
+                                            manager.volume = volume;
                                         },
                                         Err(_) => {
                                             //failed to set volume
@@ -116,6 +117,7 @@ pub fn load_a_song_from_path(audio_manager: State<'_, Mutex<SharedAudioManager>>
                                     match handle.set_volume(volume, Tween::default()){
                                         Ok(_) => {
                                             //set volume
+                                            manager.volume = volume;
                                         },
                                         Err(_) => {
                                             //failed to set volume
@@ -226,31 +228,13 @@ pub fn resume_playing(audio_manager: State<'_, Mutex<SharedAudioManager>>){
 pub fn seek_to(audio_manager: State<'_, Mutex<SharedAudioManager>>, position: f64){
     match audio_manager.lock(){
         Ok(mut manager) => {
+            //get volume
+            let volume = manager.volume.clone();
             match &mut manager.instance_handle{
                 Some(handle) => {
                     match handle.seek_to(position){
                         Ok(_) => {
-                            //seeked to position
-                            //there seems to be a weird issue where the song will seek correctly
-                            //but the position will not update until the song is resumed
-                            //so we will lower the volume to 0, play, then pause, then restore the previous volume
-                            //this is a hacky solution but it works
-                            match handle.resume(Tween::default()){
-                                Ok(_) => {
-                                    //resumed song
-                                    match handle.pause(Tween::default()){
-                                        Ok(_) => {
-                                            //paused song
-                                        },
-                                        Err(_) => {
-                                            //failed to pause song
-                                        },
-                                    }
-                                },
-                                Err(_) => {
-                                    //failed to resume song
-                                },
-                            }
+                            handle_true_seeking(handle, volume);
                         },
                         Err(_) => {
                             //failed to seek to position
@@ -299,6 +283,7 @@ pub fn set_volume(audio_manager: State<'_, Mutex<SharedAudioManager>>, volume: f
                     match handle.set_volume(volume, Tween::default()){
                         Ok(_) => {
                             //set volume
+                            manager.volume = volume;
                         },
                         Err(_) => {
                             //failed to set volume
@@ -312,6 +297,63 @@ pub fn set_volume(audio_manager: State<'_, Mutex<SharedAudioManager>>, volume: f
         },
         Err(_) => {
             //failed to lock audio manager
+        },
+    }
+}
+
+fn handle_true_seeking(handle: &mut StreamingSoundHandle<FromFileError>, volume: f64){
+    //seeked to position
+    //there seems to be a weird issue(maybe it's intended to be that way in kira) where the song will seek correctly
+    //but the position will not update until the song is resumed
+    //Resuming and pausing the song immediately after seems to be unable to fix this
+    //but the seeker only updates if the song is resumed and allowed to play without being immediately paused
+    //so we resume the song and then pause it after a short delay
+    //this is a hacky solution but it works
+
+    //the source of the problem is that when a song is playing, it loads the next chunk of audio data into memory
+    //and so when it is paused, that chunk of audio data is still in memory
+    //so even if you seek to a new spot, the audio data that was loaded into memory is still there
+    //so it will have to be played either way before the new seeked to position can be played
+    //the only way around this would be to figure out how to clear the audio data from memory
+    //or how long the audio data that we want to skip past is and just allow the song to play for that long
+    //before pausing it again whilst the volume is 0.0. Hopefully the user won't notice this because
+    //that delay may get as large as 200ms or so depending on the size of the audio data that was loaded into memory
+
+    match handle.set_volume(0.0, Tween::default()){
+        Ok(_) => {
+            //set volume
+        },
+        Err(_) => {
+            //failed to set volume
+        },
+    }
+
+    match handle.resume(Tween::default()){
+        Ok(_) => {
+            //resumed song
+            //pause the song after a short delay
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            match handle.pause(Tween::default()){
+                Ok(_) => {
+                    //paused song
+                },
+                Err(_) => {
+                    //failed to pause song
+                },
+            }
+        },
+        Err(_) => {
+            //failed to resume song
+        },
+    }
+
+    //reset volume back to previous value
+    match handle.set_volume(volume, Tween::default()){
+        Ok(_) => {
+            //set volume
+        },
+        Err(_) => {
+            //failed to set volume
         },
     }
 }

--- a/muzik-offline/src/database/saved_object.ts
+++ b/muzik-offline/src/database/saved_object.ts
@@ -15,10 +15,13 @@ export interface SavedObject{
     OStype: string,
     CompressImage: string,
     UpcomingHistoryLimit: string,
+    SeekStepAmount: string,
+    SongLengthORremaining: string,
+
 }
 
 export const emptySavedObject: SavedObject = {
-    LaunchTab: "Home page",
+    LaunchTab: "All tracks",
     AppActivityDiscord: "No",
     BGColour: "blue_purple_gradient",
     ThemeColour: "blueberry",
@@ -32,4 +35,6 @@ export const emptySavedObject: SavedObject = {
     OStype: OSTYPEenum.Windows,
     CompressImage: "No",
     UpcomingHistoryLimit: "10",
+    SeekStepAmount: "10",
+    SongLengthORremaining: "song length",
 }

--- a/muzik-offline/src/interface/components/music/AppMusicPlayer.tsx
+++ b/muzik-offline/src/interface/components/music/AppMusicPlayer.tsx
@@ -51,6 +51,12 @@ const AppMusicPlayer : FunctionComponent<AppMusicPlayerProps> = (props: AppMusic
                 if(Player.isPlaying)pauseSong();
                 else playSong();
             }
+            else if(ev.key === "ArrowRight"){//seek to 10 seconds ahead
+
+            }
+            else if(ev.key === "ArrowLeft"){//seek to 10 seconds behind
+
+            }
         }
     }
 
@@ -125,7 +131,15 @@ const AppMusicPlayer : FunctionComponent<AppMusicPlayerProps> = (props: AppMusic
                                 onChange={draggingSeeker} 
                                 onMouseUp={changeSeeker}
                                 style={{backgroundSize: playingPosition.toString() + "% 100%"}}/>
-                            <p>{Player.playingSongMetadata ? secondsToTimeFormat(Player.lengthOfSongInSeconds) : "~"}</p>
+                            <p>
+                                {Player.playingSongMetadata ? 
+                                    secondsToTimeFormat(
+                                        local_store.SongLengthORremaining === "song length" ?
+                                            Player.lengthOfSongInSeconds : Player.lengthOfSongInSeconds - playingPosInSec
+                                    ) 
+                                    : 
+                                    "~"}
+                            </p>
                         </div>
                     </div>
                     <div className="more_controls_cast_and_volume_controller">

--- a/muzik-offline/src/interface/components/music/AppMusicPlayer.tsx
+++ b/muzik-offline/src/interface/components/music/AppMusicPlayer.tsx
@@ -3,10 +3,10 @@ import "@styles/components/music/AppMusicPlayer.scss";
 import {ChromeCast, DotHorizontal, NullCoverNull, Pause, Play, Repeat, RepeatOne, Shuffle, SkipBack, SkipFwd, VolumeMax, VolumeMin} from "@icons/index"
 import { motion } from "framer-motion";
 import { usePlayerStore, usePlayingPosition, usePlayingPositionSec, useSavedObjectStore } from "store";
-import { getRandomCover, secondsToTimeFormat } from "utils";
+import { getRandomCover, secondsToTimeFormat } from "@utils/index";
 import { invoke } from "@tauri-apps/api";
-import { changeVolumeLevel, changeSeekerPosition, changeVolumeLevelBtnPress, dragSeeker, pauseSong, playSong, repeatToggle, shuffleToggle, setVolumeLevel, reconfigurePlayer_AtEndOfSong, playPreviousSong, playNextSong } from "utils/playerControl";
-import { AirplayCastModal } from "..";
+import { changeVolumeLevel, changeSeekerPosition, changeVolumeLevelBtnPress, dragSeeker, pauseSong, playSong, repeatToggle, shuffleToggle, setVolumeLevel, reconfigurePlayer_AtEndOfSong, playPreviousSong, playNextSong, changeSeekerPositionBtnPress } from "@utils/playerControl";
+import { AirplayCastModal } from "@components/index";
 
 type AppMusicPlayerProps = {
     openPlayer: () => void;
@@ -51,12 +51,8 @@ const AppMusicPlayer : FunctionComponent<AppMusicPlayerProps> = (props: AppMusic
                 if(Player.isPlaying)pauseSong();
                 else playSong();
             }
-            else if(ev.key === "ArrowRight"){//seek to 10 seconds ahead
-
-            }
-            else if(ev.key === "ArrowLeft"){//seek to 10 seconds behind
-
-            }
+            else if(ev.key === "ArrowRight")changeSeekerPositionBtnPress(false);
+            else if(ev.key === "ArrowLeft")changeSeekerPositionBtnPress(true);
         }
     }
 

--- a/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
@@ -35,7 +35,7 @@ const settings_data: {
         key: 4,
         title: "Show song length or time until song ends",
         dropDownName: selectedGeneralSettingEnum.SongLengthORremaining,
-        options: ["song length", "time until song ends"]
+        options: ["song length", "song ends"]
     },
 ]
 

--- a/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
@@ -29,7 +29,7 @@ const settings_data: {
         key: 3,
         title: "Left/right arrows seeking seconds amount",
         dropDownName: selectedGeneralSettingEnum.SeekStepAmount,
-        options: ["5", "10", "20", "40"]
+        options: ["5", "10", "15", "20", "30", "60"]
     },
     {
         key: 4,

--- a/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
@@ -15,7 +15,7 @@ const settings_data: {
 }[] = [
     {
         key: 1,
-        title: "Compress images to save space",
+        title: "Compress song images(will only be compressed on subsequent directory scans)",
         dropDownName: selectedGeneralSettingEnum.CompressImage,
         options: ["Yes", "No"]
     },
@@ -24,6 +24,18 @@ const settings_data: {
         title: "Upcoming/History songs limit",
         dropDownName: selectedGeneralSettingEnum.UpcomingHistoryLimit,
         options: ["5", "10", "15", "20"]
+    },
+    {
+        key: 3,
+        title: "Left/right arrows seeking seconds amount",
+        dropDownName: selectedGeneralSettingEnum.SeekStepAmount,
+        options: ["5", "10", "20", "40"]
+    },
+    {
+        key: 4,
+        title: "Show song length or time until song ends",
+        dropDownName: selectedGeneralSettingEnum.SongLengthORremaining,
+        options: ["song length", "time until song ends"]
     },
 ]
 

--- a/muzik-offline/src/types/index.ts
+++ b/muzik-offline/src/types/index.ts
@@ -13,6 +13,8 @@ export enum selectedGeneralSettingEnum{
     VolumeStepAmount = "VolumeStepAmount",
     CompressImage = "CompressImage",
     UpcomingHistoryLimit = "UpcomingHistoryLimit",
+    SeekStepAmount = "SeekStepAmount",
+    SongLengthORremaining = "SongLengthORremaining"
 }
 
 export enum OSTYPEenum{

--- a/muzik-offline/src/utils/playerControl.ts
+++ b/muzik-offline/src/utils/playerControl.ts
@@ -155,22 +155,22 @@ export function changeSeekerPosition(value: number){
 export function changeSeekerPositionBtnPress(isDecreasing: boolean){
     if(usePlayerStore.getState().Player.playingSongMetadata === null)return;
     const position = usePlayingPositionSec.getState().position;
+    const seekstepamount = parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
+    if(position <= 0 || position >= usePlayerStore.getState().Player.lengthOfSongInSeconds)return;
+    let delta_amount = 0;
     if(isDecreasing === true){
-        if(position <= 0)return;
-        const level: number = Number(position) - parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
-        usePlayingPositionSec.getState().setPosition(level <= 0 ? 0 : level);
+        if(position <= seekstepamount)delta_amount = -(position);
+        else delta_amount = -(seekstepamount);
+        usePlayingPositionSec.getState().setPosition(position + delta_amount);
     }
     else{
-        if(position >= usePlayerStore.getState().Player.lengthOfSongInSeconds)return;
-        const level: number = Number(position) + parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
-        usePlayingPositionSec.getState().setPosition(
-            level >= usePlayerStore.getState().Player.lengthOfSongInSeconds ? 
-                usePlayerStore.getState().Player.lengthOfSongInSeconds 
-                : 
-                level);
+        if(position > usePlayerStore.getState().Player.lengthOfSongInSeconds - seekstepamount)
+            delta_amount = usePlayerStore.getState().Player.lengthOfSongInSeconds - position;
+        else delta_amount = seekstepamount;
+        usePlayingPositionSec.getState().setPosition(position + delta_amount);
     }
-    invoke("seek_to", {
-        position: usePlayingPositionSec.getState().position
+    invoke("seek_by", {
+        delta: delta_amount ? delta_amount : 10.0
     }).then(() => {if(usePlayerStore.getState().Player.wasPlayingBeforePause === true)playSong()});
 }
 

--- a/muzik-offline/src/utils/playerControl.ts
+++ b/muzik-offline/src/utils/playerControl.ts
@@ -152,6 +152,22 @@ export function changeSeekerPosition(value: number){
     invoke("seek_to", {position: position}).then(() => {if(usePlayerStore.getState().Player.wasPlayingBeforePause === true)playSong()})
 }
 
+export function changeSeekerPositionBtnPress(isDecreasing: boolean){
+    if(usePlayerStore.getState().Player.playingSongMetadata === null)return;
+    const position = usePlayingPositionSec.getState().position;
+    if(isDecreasing === true){
+        if(position <= 0)return;
+        const level: number = Number(position) - parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
+        usePlayingPositionSec.getState().setPosition(level <= 0 ? 0 : level);
+    }
+    else{
+        if(position >= usePlayerStore.getState().Player.lengthOfSongInSeconds)return;
+        const level: number = Number(position) + parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
+        usePlayingPositionSec.getState().setPosition(level >= usePlayerStore.getState().Player.lengthOfSongInSeconds ? usePlayerStore.getState().Player.lengthOfSongInSeconds : level);
+    }
+    changeSeekerPosition(usePlayingPositionSec.getState().position);
+}
+
 export function changeVolumeLevel(value: number){
     //that value is bounded between 0 and 100
     let temp: SavedObject = useSavedObjectStore.getState().local_store;

--- a/muzik-offline/src/utils/playerControl.ts
+++ b/muzik-offline/src/utils/playerControl.ts
@@ -149,7 +149,7 @@ export async function dragSeeker(){
 export function changeSeekerPosition(value: number){
     if(usePlayerStore.getState().Player.playingSongMetadata === null)return;
     const position = (value / 100) * usePlayerStore.getState().Player.lengthOfSongInSeconds;
-    invoke("seek_to", {position: position}).then(() => {if(usePlayerStore.getState().Player.wasPlayingBeforePause === true)playSong()})
+    invoke("seek_to", {position: position}).then(() => {if(usePlayerStore.getState().Player.wasPlayingBeforePause === true)playSong()});
 }
 
 export function changeSeekerPositionBtnPress(isDecreasing: boolean){
@@ -163,9 +163,15 @@ export function changeSeekerPositionBtnPress(isDecreasing: boolean){
     else{
         if(position >= usePlayerStore.getState().Player.lengthOfSongInSeconds)return;
         const level: number = Number(position) + parseInt(useSavedObjectStore.getState().local_store.SeekStepAmount);
-        usePlayingPositionSec.getState().setPosition(level >= usePlayerStore.getState().Player.lengthOfSongInSeconds ? usePlayerStore.getState().Player.lengthOfSongInSeconds : level);
+        usePlayingPositionSec.getState().setPosition(
+            level >= usePlayerStore.getState().Player.lengthOfSongInSeconds ? 
+                usePlayerStore.getState().Player.lengthOfSongInSeconds 
+                : 
+                level);
     }
-    changeSeekerPosition(usePlayingPositionSec.getState().position);
+    invoke("seek_to", {
+        position: usePlayingPositionSec.getState().position
+    }).then(() => {if(usePlayerStore.getState().Player.wasPlayingBeforePause === true)playSong()});
 }
 
 export function changeVolumeLevel(value: number){


### PR DESCRIPTION
# Changelog
1. Adding volume parameter to ```SharedAudioManager``` to keep track of the audio volume level as kira does not have a ```get_volume()``` function.
2. Added ```seek_by``` function exposed to the frontend. This function will allow seeking by a specified value, so if the value is 2secs, it will seek the playing position of a song 2secs ahead.
3. Added a delay to seeking using the ```handle_true_seeking``` function. There are comments there that explain further the issues and the reasoning for why that function exists. The function can be found in <a href="https://github.com/muzik-apps/muzik-offline/blob/making-seeker-easier-to-use-dev/muzik-offline/src-tauri/src/music/player.rs">player.rs</a>