### PR TITLE
fixing file reveal bug

### DIFF
--- a/muzik-offline/src-tauri/src/commands/general_commands.rs
+++ b/muzik-offline/src-tauri/src/commands/general_commands.rs
@@ -36,6 +36,7 @@ pub async fn resize_frontend_image_to_fixed_height(image_as_str: String, height:
 #[cfg(target_os = "macos")]
 fn open_file_at(file_path: &str) {
     match Command::new( "open" )
+        .arg("-R")
         .arg( file_path ) // <- Specify the directory you'd like to open.
         .spawn( )
     {
@@ -51,6 +52,7 @@ fn open_file_at(file_path: &str) {
 #[cfg(target_os = "windows")]
 fn open_file_at(file_path: &str) {
     match Command::new( "explorer" )
+        .arg("/select,")
         .arg( file_path ) // <- Specify the directory you'd like to open.
         .spawn( )
     {


### PR DESCRIPTION
When a user chose to reveal a song when viewing it's properties, it would open the file with the default music app instead of revealing it in the file manager. The issue has now been addressed on windows and macos, however for linux based systems, since there is no universal command, the issue will remain unfixed. If a user using a linux based distro anticipates they will be using a specific file manager, they can build a binary with the specific name and command embedded into this file.