### PR TITLE
Limited strange fullscreen switching to windows

### DIFF
--- a/muzik-offline/src/interface/components/music/FSMusicPlayer.tsx
+++ b/muzik-offline/src/interface/components/music/FSMusicPlayer.tsx
@@ -33,7 +33,7 @@ const FSMusicPlayer: FunctionComponent<FSMusicPlayerProps> = (props: FSMusicPlay
 
     async function switchtoFS(){
         const isMaximized: boolean = await appWindow.isMaximized();
-        if(isMaximized === true){
+        if(isMaximized === true && local_store.OStype === OSTYPEenum.Windows){
             setMaximized(true);
             appWindow.unmaximize();
         }
@@ -47,7 +47,7 @@ const FSMusicPlayer: FunctionComponent<FSMusicPlayerProps> = (props: FSMusicPlay
         appWindow.setResizable(true);
         setappFS(false);
 
-        if(wasMaximized === true){
+        if(wasMaximized === true && local_store.OStype === OSTYPEenum.Windows){
             setMaximized(false);
             appWindow.maximize();
         }


### PR DESCRIPTION
Full screen switching sometimes refused to work when the app was maximized and so a function was created to mitigate this. This update limits this feature to windows as it has been observed to only occur on windows