### PR TITLE
Refactor FSMusicPlayer navbar buttons

### DIFF
--- a/muzik-offline/src/interface/components/music/FSMusicPlayer.tsx
+++ b/muzik-offline/src/interface/components/music/FSMusicPlayer.tsx
@@ -81,16 +81,31 @@ const FSMusicPlayer: FunctionComponent<FSMusicPlayerProps> = (props: FSMusicPlay
                             </motion.div>}
                     </div>
                     <div className="frontward_facing_player">
-                        <div className="navbar_buttons">
-                            {   appFS === false &&
-                                    (<motion.div className={"close_full_screen_player_btn" + (appFS === false && " give-margin")} onClick={props.closePlayer} whileTap={{scale: 0.98}}>
-                                        <Minimize /><h3>close</h3>
-                                    </motion.div> )
-                            }
-                            <motion.div className="toggle_full_screen_player_btn" onClick={appFS === true ? switchtoNONFS : switchtoFS} whileTap={{scale: 0.98}}>
-                                { appFS === false ?  (<><Overlap /><h3>fullscreen</h3></>) : (<><Minimize /><h3>minimize</h3></>) }
-                            </motion.div> 
-                        </div>
+                        {local_store.OStype === OSTYPEenum.Windows ?
+                            <div className="navbar_container" data-tauri-drag-region>
+                                <div className="navbar_buttons">
+                                    {   appFS === false &&
+                                            (<motion.div className={"close_full_screen_player_btn" + (appFS === false && " give-margin")} onClick={props.closePlayer} whileTap={{scale: 0.98}}>
+                                                <Minimize /><h3>close</h3>
+                                            </motion.div> )
+                                    }
+                                    <motion.div className="toggle_full_screen_player_btn" onClick={appFS === true ? switchtoNONFS : switchtoFS} whileTap={{scale: 0.98}}>
+                                        { appFS === false ?  (<><Overlap /><h3>fullscreen</h3></>) : (<><Minimize /><h3>minimize</h3></>) }
+                                    </motion.div> 
+                                </div>
+                            </div>
+                            :
+                            <div className="navbar_buttons">
+                                {   appFS === false &&
+                                        (<motion.div className={"close_full_screen_player_btn" + (appFS === false && " give-margin")} onClick={props.closePlayer} whileTap={{scale: 0.98}}>
+                                            <Minimize /><h3>close</h3>
+                                        </motion.div> )
+                                }
+                                <motion.div className="toggle_full_screen_player_btn" onClick={appFS === true ? switchtoNONFS : switchtoFS} whileTap={{scale: 0.98}}>
+                                    { appFS === false ?  (<><Overlap /><h3>fullscreen</h3></>) : (<><Minimize /><h3>minimize</h3></>) }
+                                </motion.div> 
+                            </div>
+                        }
                         {props.openPlayer && isDoneOpening &&
                                 <motion.div className="main_visible_content"
                                     animate={props.openPlayer && isDoneOpening ? "open" : "closed"}

--- a/muzik-offline/src/interface/styles/components/music/FSMusicPlayer.scss
+++ b/muzik-offline/src/interface/styles/components/music/FSMusicPlayer.scss
@@ -68,6 +68,10 @@
             margin-top: -110vh;
             background: $blur-element;
             position: absolute;
+
+            .navbar_container{
+                width: 100%;
+            }
             
             .navbar_buttons{
                 margin-top: 10px;


### PR DESCRIPTION
Added a draggable region for windows OS when the player goes full-screen but the application itself is not full-screen
ref issue: https://github.com/muzik-apps/muzik-offline/issues/22