### PR TITLE
Fix context menu rendering bug

### DIFF
--- a/muzik-offline/src/interface/layouts/HistoryNextFloating.tsx
+++ b/muzik-offline/src/interface/layouts/HistoryNextFloating.tsx
@@ -153,7 +153,7 @@ const HistoryNextFloating : FunctionComponent<HistoryNextFloatingProps> = (props
                 }
             </motion.div>
             {
-                state.songMenuToOpen && (
+                state.songMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="HistoryNextFloating-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/layouts/SearchSongs.tsx
+++ b/muzik-offline/src/interface/layouts/SearchSongs.tsx
@@ -126,7 +126,7 @@ const SearchSongs = () => {
                 <div className="AllTracks_container_bottom_margin"/>
             </div>
             {
-                state.songMenuToOpen && (
+                state.songMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="SearchSongs-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/AllAlbums.tsx
+++ b/muzik-offline/src/interface/pages/AllAlbums.tsx
@@ -103,7 +103,7 @@ const AllAlbums = () => {
                 )}
             </div>
             {
-                state.albumMenuToOpen && (
+                state.albumMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="AllAlbums-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/AllArtists.tsx
+++ b/muzik-offline/src/interface/pages/AllArtists.tsx
@@ -106,7 +106,7 @@ const AllArtists = () => {
                     )}
             </div>
             {
-                state.artistMenuToOpen && (
+                state.artistMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="AllArtists-ContextMenu-container"  
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/AllGenres.tsx
+++ b/muzik-offline/src/interface/pages/AllGenres.tsx
@@ -103,7 +103,7 @@ const AllGenres = () => {
                     )}
             </div>
             {
-                state.genreMenuToOpen && (
+                state.genreMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="AllGenres-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/AllPlaylists.tsx
+++ b/muzik-offline/src/interface/pages/AllPlaylists.tsx
@@ -107,7 +107,7 @@ const AllPlaylists = () => {
                     )}
             </div>
             {
-                state.playlistMenuToOpen && (
+                state.playlistMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="AllPlaylists-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/ArtistCatalogue.tsx
+++ b/muzik-offline/src/interface/pages/ArtistCatalogue.tsx
@@ -114,7 +114,7 @@ const ArtistCatalogue = () => {
                 <div className="footer_content"/>
             </div>
             {
-                state.albumMenuToOpen && (
+                state.albumMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="ArtistCatalogue-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 

--- a/muzik-offline/src/interface/pages/GenreView.tsx
+++ b/muzik-offline/src/interface/pages/GenreView.tsx
@@ -173,7 +173,7 @@ const GenreView = () => {
                 </div>
             </motion.div>
             {
-                state.songMenuToOpen && (
+                state.songMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0 && (
                     <div className="GenreView-ContextMenu-container" 
                         onClick={(e) => closeContextMenu(dispatch, e)} onContextMenu={(e) => closeContextMenu(dispatch, e)}>
                         <GeneralContextMenu 


### PR DESCRIPTION
This fix will prevent the context menu from showing up due to random key presses.
More checks were introduced to prevent the context menu from activating. Before the context menu would activate if a song was selected and the right mouse button was clicked. Now the context menu itself has to not have a position of (0,0) in order to render also:
```state.songMenuToOpen && state.co_ords.xPos != 0 && state.co_ords.yPos != 0```

ref issue: https://github.com/muzik-apps/muzik-offline/issues/21