### PR TITLE
Fix error handling in DiscordRpc

### DIFF
--- a/muzik-offline/src-tauri/src/socials/discord_rpc.rs
+++ b/muzik-offline/src-tauri/src/socials/discord_rpc.rs
@@ -86,7 +86,7 @@ impl DiscordRpc {
             Ok(())
         }
         else{
-            Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "not connected to discord rpc")))
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
This addresses an issue whereby if the discord app is closed and a user tries to set the connection to off, the app refuses to allow the user to do so even though they should be able to do so.
issue ref: https://github.com/muzik-apps/muzik-offline/issues/20