### PR TITLE
Update playlist metadata structure

### DIFF
--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -866,6 +866,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,17 +2106,16 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.17.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d514acc39ec2bee7392e451db35e5f5eb06ab26e1cae83746c3017e8c95099"
+checksum = "f75066eb1d25a7047fb2667edb410ae2592439ed81546f95c28b0a1c7d7d3818"
 dependencies = [
- "base64 0.21.7",
  "byteorder",
+ "data-encoding",
  "flate2",
  "lofty_attr",
  "log",
  "ogg_pager",
- "once_cell",
  "paste",
 ]
 
@@ -2534,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "ogg_pager"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d218a406e5de88e1c492d0162d569916f7436efe851ba5cc40a4bf4fa97cb40"
+checksum = "c949d63b387b25c332f6e39d1762dd4b405008289dd7681f02c258b1294653ca"
 dependencies = [
  "byteorder",
 ]

--- a/muzik-offline/src/interface/pages/AlbumDetails.tsx
+++ b/muzik-offline/src/interface/pages/AlbumDetails.tsx
@@ -74,11 +74,11 @@ const AlbumDetails = () => {
     async function setAlbumSongs(){
         if(album_key === undefined)return;
         dispatch({ type: reducerType.SET_LOADING, payload: true});
-        const albumres = await local_albums_db.albums.where("key").equals(Number.parseInt(album_key)).toArray();
-        if(albumres.length !== 1)return;
-        const result = await getAlbumSongs(albumres[0], artist_name && artist_name !== "undefined" ? artist_name : "");
+        const albumres = await local_albums_db.albums.where("key").equals(Number.parseInt(album_key)).first();
+        if(albumres === undefined)return;
+        const result = await getAlbumSongs(albumres, artist_name && artist_name !== "undefined" ? artist_name : "");
         dispatch({ type: reducerType.SET_ALBUM_METADATA, payload: {
-                cover: result.cover, title: albumres[0].title, artist: result.songs[0].artist,
+                cover: result.cover, title: albumres.title, artist: result.songs[0].artist,
                 year: result.songs[0].year.toString(),song_count: result.songs.length,
                 length: secondsToTimeFormat(result.totalDuration)
             }

--- a/muzik-offline/src/interface/pages/GenreView.tsx
+++ b/muzik-offline/src/interface/pages/GenreView.tsx
@@ -67,11 +67,11 @@ const GenreView = () => {
 
     async function setAlbumSongs(){
         if(genre_key === undefined)return;
-        const genreres = await local_genres_db.genres.where("key").equals(Number.parseInt(genre_key)).toArray();
-        if(genreres.length !== 1)return;
-        const result = await getGenreSongs(genreres[0]);
+        const genreres = await local_genres_db.genres.where("key").equals(Number.parseInt(genre_key)).first();
+        if(genreres === undefined)return;
+        const result = await getGenreSongs(genreres);
         dispatch({ type: reducerType.SET_GENRE_METADATA, payload: {
-            cover: result.cover, genreName: genreres[0].title,
+            cover: result.cover, genreName: genreres.title,
             song_count: result.songs.length,
             length: secondsToTimeFormat(result.totalDuration)
             }

--- a/muzik-offline/src/interface/pages/PlaylistView.tsx
+++ b/muzik-offline/src/interface/pages/PlaylistView.tsx
@@ -67,11 +67,11 @@ const PlaylistView = () => {
 
     async function closeModalAndResetData(){
         dispatch({ type: reducerType.SET_EDIT_PLAYLIST_MODAL, payload: false});
-        const playlistres = await local_playlists_db.playlists.where("key").equals(state.playlist_metadata.key).toArray();
-        if(playlistres.length !== 1)return;
+        if(state.playlist_metadata.playlist_data === null)return;
+        const playlistres = await local_playlists_db.playlists.where("key").equals(state.playlist_metadata.playlist_data.key).first();
+        if(playlistres === undefined)return;
         dispatch({ type: reducerType.SET_PLAYLIST_METADATA, payload: {
-            key: state.playlist_metadata.key,
-            cover: playlistres[0].cover, playlistName: playlistres[0].title,
+            playlist_data: playlistres,
             song_count: state.playlist_metadata.song_count,
             length: state.playlist_metadata.length
             }
@@ -80,12 +80,11 @@ const PlaylistView = () => {
 
     async function setPlaylistSongs(){
         if(playlist_key === undefined)return;
-        const playlistres = await local_playlists_db.playlists.where("key").equals(Number.parseInt(playlist_key)).toArray();
-        if(playlistres.length !== 1)return;
-        const result = await getPlaylistSongs(playlistres[0]);
+        const playlistres = await local_playlists_db.playlists.where("key").equals(Number.parseInt(playlist_key)).first();
+        if(playlistres === undefined)return;
+        const result = await getPlaylistSongs(playlistres);
         dispatch({ type: reducerType.SET_PLAYLIST_METADATA, payload: {
-            key: playlistres[0].key,
-            cover: playlistres[0].cover, playlistName: playlistres[0].title,
+            playlist_data: playlistres,
             song_count: result.songs.length,
             length: secondsToTimeFormat(result.totalDuration)
             }
@@ -137,9 +136,9 @@ const PlaylistView = () => {
         animate={{scale: 1, opacity: 1}}
         exit={{scale: 0.9, opacity: 0}}>
             <div className="header_content">
-                <LargeResizableCover id={playlist_key} resizeHeader={state.resizeHeader} cover={state.playlist_metadata.cover} />
+                <LargeResizableCover id={playlist_key} resizeHeader={state.resizeHeader} cover={state.playlist_metadata.playlist_data?.cover} />
                 <div className="details">
-                    <h2 style={{ marginTop: state.resizeHeader ? "25px" : "68px" }}>{state.playlist_metadata.playlistName}</h2>
+                    <h2 style={{ marginTop: state.resizeHeader ? "25px" : "68px" }}>{state.playlist_metadata.playlist_data?.title}</h2>
                     { !state.resizeHeader &&
                         <>
                             <h4>{state.playlist_metadata.song_count} {state.playlist_metadata.song_count > 1 ? "songs" : "song"}</h4>
@@ -202,7 +201,8 @@ const PlaylistView = () => {
                 )
             }
             <EditPlaylistModal 
-                playlistobj={{key: state.playlist_metadata.key, cover: state.playlist_metadata.cover, title: state.playlist_metadata.playlistName, dateCreated: "", dateEdited: "", tracksPaths: []}}
+                playlistobj={state.playlist_metadata.playlist_data ? state.playlist_metadata.playlist_data
+                    : {key: 0, title: "", cover: null, dateCreated: "", dateEdited: "", tracksPaths: []}}
                 isOpen={state.isEditingPlayListModalOpen} closeModal={closeModalAndResetData}/>
             <AddSongToPlaylistModal isOpen={state.isPlaylistModalOpen} songPath={state.songMenuToOpen ? state.songMenuToOpen.path : ""} closeModal={() => closePlaylistModal(dispatch)} />
             <PropertiesModal isOpen={state.isPropertiesModalOpen} song={state.songMenuToOpen ? state.songMenuToOpen : undefined} closeModal={() => closePropertiesModal(dispatch)} />

--- a/muzik-offline/src/store/reducerStore.ts
+++ b/muzik-offline/src/store/reducerStore.ts
@@ -214,7 +214,7 @@ export const PlaylistViewState: PlaylistViewInterface = {
     selected: 0,
     co_ords: { xPos: 0, yPos: 0 },
     SongList: [],
-    playlist_metadata: {key: 0,cover: null,playlistName: "",song_count: 0,length: ""},
+    playlist_metadata: {playlist_data: null,song_count: 0,length: ""},
     songMenuToOpen: null,
     isEditingPlayListModalOpen: false,
     isPlaylistModalOpen: false,

--- a/muzik-offline/src/types/index.ts
+++ b/muzik-offline/src/types/index.ts
@@ -137,9 +137,7 @@ export interface GenreMD {
 }
 
 export interface PlaylistMD {
-    key: number;
-    cover: string | null;
-    playlistName: string;
+    playlist_data: playlist | null,
     song_count: number;
     length: string;
 }


### PR DESCRIPTION
# Updates include:
1. Fixed a bug where the playlist would delete all tracks in it if a user changed the playlist name or playlist image cover
2. Updated structure of playlist metadata
3. Made it so that when a genre, album or playlist object is fetched from the database, it returns a singular object instead of an object contained in an array.