### PR TITLE
Playlist page redesign

### DIFF
--- a/muzik-offline/package-lock.json
+++ b/muzik-offline/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muzik-offline",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muzik-offline",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^1.5.1",
         "dexie": "^3.2.4",

--- a/muzik-offline/package.json
+++ b/muzik-offline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muzik-offline",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "muzik-offline"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64 0.21.7",
  "dirs",

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muzik-offline"
-version = "0.3.1"
+version = "0.4.0"
 description = "A desktop music player for listening to music offline."
 authors = ["Michael"]
 license = ""

--- a/muzik-offline/src-tauri/tauri.conf.json
+++ b/muzik-offline/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "muzik-offline",
-    "version": "0.3.1"
+    "version": "0.4.0"
   },
   "tauri": {
     "allowlist": {

--- a/muzik-offline/src/assets/icons/General/AlertTriangle.tsx
+++ b/muzik-offline/src/assets/icons/General/AlertTriangle.tsx
@@ -1,0 +1,9 @@
+const AlertTriangle = () => {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 12.9708V8.13251M12 16.5571V16.5996M18.0479 20.6292H5.9521C4.29987 20.6292 2.90554 19.525 2.46685 18.0143C2.27959 17.3694 2.50969 16.6977 2.86163 16.1257L8.90956 5.09779C10.3265 2.7952 13.6735 2.7952 15.0905 5.0978L21.1384 16.1257C21.4904 16.6977 21.7205 17.3694 21.5332 18.0143C21.0945 19.525 19.7002 20.6292 18.0479 20.6292Z" stroke="#FF6B00" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+    )
+}
+
+export default AlertTriangle

--- a/muzik-offline/src/assets/icons/General/Trash.tsx
+++ b/muzik-offline/src/assets/icons/General/Trash.tsx
@@ -1,0 +1,9 @@
+const Trash = () => {
+    return (
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M2.40002 5.40005H21.6M8.40002 1.80005H15.6M9.60002 17.4V10.2M14.4 17.4V10.2M16.2 22.2H7.80002C6.47454 22.2 5.40002 21.1255 5.40002 19.8L4.85211 6.65001C4.8237 5.96826 5.36872 5.40005 6.05106 5.40005H17.949C18.6313 5.40005 19.1763 5.96826 19.1479 6.65001L18.6 19.8001C18.6 21.1255 17.5255 22.2 16.2 22.2Z" stroke="#ECECEC" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+    )
+}
+
+export default Trash

--- a/muzik-offline/src/assets/icons/index.ts
+++ b/muzik-offline/src/assets/icons/index.ts
@@ -48,6 +48,8 @@ import Edit from './General/Edit';
 import Overlap from './Layout/Overlap';
 import Minimize from './Layout/Minimize';
 import ListIcon from './General/ListIcon';
+import AlertTriangle from './General/AlertTriangle';
+import Trash from './General/Trash';
 
 export {
     Next_page, Prev_page, Search, 
@@ -63,5 +65,5 @@ export {
     NullArtistCoverOne, NullArtistCoverTwo, NullArtistCoverThree, NullArtistCoverFour,
     CheckGreen, CrossRed, InformationCircleContainedOrange, InformationCircleContainedBlue,
     EditImage, Edit, Overlap, Minimize,
-    ListIcon, 
+    ListIcon, AlertTriangle, Trash
 }

--- a/muzik-offline/src/interface/components/context_menu/ContextMenuButtons.tsx
+++ b/muzik-offline/src/interface/components/context_menu/ContextMenuButtons.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react';
 import { contextMenuButtons } from 'types';
-import { ArrowCurveLeftRight, ArrowCurveRightUp, Disk, InformationCircleContained, LayersThree, Menu, Microphone, Play } from '@assets/icons';
+import { ArrowCurveLeftRight, ArrowCurveRightUp, Disk, InformationCircleContained, LayersThree, Menu, Microphone, Play, Trash } from '@assets/icons';
 import { motion } from 'framer-motion';
 
 type ContextMenuButtonsProps = {
@@ -86,6 +86,15 @@ export const ShowInfoButton: FunctionComponent<ContextMenuButtonsProps> = (props
         <motion.div className="ShowInfo" whileTap={{scale: 0.98}} onMouseDown={() => props.chooseOption(contextMenuButtons.ShowInfo)}>
             <InformationCircleContained />
             <p>Properties</p>
+        </motion.div>
+    )
+}
+
+export const DeleteButton: FunctionComponent<ContextMenuButtonsProps> = (props: ContextMenuButtonsProps) => {
+    return (
+        <motion.div className="DeleteButton" whileTap={{scale: 0.98}} onMouseDown={() => props.chooseOption(contextMenuButtons.Delete)}>
+            <Trash />
+            <p>Delete "{props.title}"</p>
         </motion.div>
     )
 }

--- a/muzik-offline/src/interface/components/context_menu/GeneralContextMenu.tsx
+++ b/muzik-offline/src/interface/components/context_menu/GeneralContextMenu.tsx
@@ -3,8 +3,8 @@ import { FunctionComponent } from "react";
 import { AddToPlaylistButton, PlayButton,
     PlayLaterButton, PlayNextButton, ShowArtistButton, 
     ShowGenreButton, ShowPlaylistButton, 
-    ShowAlbumButton, 
-    ShowInfoButton} from "@components/index";
+    ShowAlbumButton, ShowInfoButton,
+    DeleteButton} from "@components/index";
 import "@styles/components/context_menu/GeneralContextMenu.scss";
 import { motion } from "framer-motion";
 
@@ -51,13 +51,17 @@ const GeneralContextMenu: FunctionComponent<GeneralContextMenuProps> = (props: G
             <PlayNextButton chooseOption={props.chooseOption}/>
             <PlayLaterButton chooseOption={props.chooseOption}/>
             {(props.CMtype === contextMenuEnum.ArtistCM) && <ShowArtistButton title={props.title} chooseOption={props.chooseOption}/>}
-            {(props.CMtype === contextMenuEnum.ArtistCM || props.CMtype === contextMenuEnum.SongCM || props.CMtype === contextMenuEnum.AlbumCM
+            {(props.CMtype === contextMenuEnum.ArtistCM || props.CMtype === contextMenuEnum.SongCM 
+                || props.CMtype === contextMenuEnum.AlbumCM || props.CMtype === contextMenuEnum.PlaylistSongsCM
                 || props.CMtype === contextMenuEnum.GenreCM  || props.CMtype === contextMenuEnum.PlaylistCM) 
                 && <AddToPlaylistButton chooseOption={props.chooseOption}/>}
             {(props.CMtype === contextMenuEnum.GenreCM) && <ShowGenreButton  title={props.title} chooseOption={props.chooseOption}/>}
             {(props.CMtype === contextMenuEnum.PlaylistCM) && <ShowPlaylistButton  title={props.title} chooseOption={props.chooseOption}/>}
-            {(props.CMtype === contextMenuEnum.AlbumCM) && <ShowAlbumButton  title={props.title} chooseOption={props.chooseOption}/>}
-            {(props.CMtype === contextMenuEnum.PlaylistCM || props.CMtype === contextMenuEnum.SongCM) && <ShowInfoButton chooseOption={props.chooseOption}/>}
+            {(props.CMtype === contextMenuEnum.AlbumCM) && <ShowAlbumButton title={props.title} chooseOption={props.chooseOption}/>}
+            {(props.CMtype === contextMenuEnum.PlaylistCM || props.CMtype === contextMenuEnum.SongCM || props.CMtype === contextMenuEnum.PlaylistSongsCM) 
+                && <ShowInfoButton chooseOption={props.chooseOption}/>}
+            {(props.CMtype === contextMenuEnum.PlaylistCM || props.CMtype === contextMenuEnum.PlaylistSongsCM) 
+            && <DeleteButton title={props.title} chooseOption={props.chooseOption}/>}
         </motion.div >
     )
 }

--- a/muzik-offline/src/interface/components/context_menu/GeneralContextMenu.tsx
+++ b/muzik-offline/src/interface/components/context_menu/GeneralContextMenu.tsx
@@ -29,14 +29,18 @@ const GeneralContextMenu: FunctionComponent<GeneralContextMenuProps> = (props: G
     function getYCoord(yPos: number){
         const winHeight: number = window.innerHeight - 35;
         let scmHeight: number = 0;
-        if(props.CMtype === contextMenuEnum.SongCM){//5 items
+        if(props.CMtype === contextMenuEnum.GenreCM){//4 items
+            scmHeight = 210;
+        }
+        else if(props.CMtype === contextMenuEnum.SongCM){//5 items
             scmHeight = 250;
         }
-        else if(props.CMtype === contextMenuEnum.ArtistCM || props.CMtype === contextMenuEnum.AlbumCM){//6 items
+        else if(props.CMtype === contextMenuEnum.ArtistCM || props.CMtype === contextMenuEnum.AlbumCM
+            || props.CMtype === contextMenuEnum.PlaylistSongsCM){//6 items
             scmHeight = 280;
         }
-        else if(props.CMtype === contextMenuEnum.PlaylistCM || props.CMtype === contextMenuEnum.GenreCM){//4 items
-            scmHeight = 210;
+        else if(props.CMtype === contextMenuEnum.PlaylistCM){//7 items
+            scmHeight = 310;
         }
         if(props.overRideY)return yPos;
         else return yPos > winHeight - scmHeight ? (winHeight - scmHeight) : yPos;

--- a/muzik-offline/src/interface/components/index.ts
+++ b/muzik-offline/src/interface/components/index.ts
@@ -33,6 +33,7 @@ import AirplayCastModal from './modals/AirplayCastModal';
 import AddSongsToPlaylistModal from './modals/AddSongsToPlaylistModal';
 import MusicPopOver from "./popover/MusicPopOver";
 import DeletePlaylistModal from './modals/DeletePlaylistModal';
+import DeleteSongFromPlaylistModal from './modals/DeleteSongFromPlaylistModal';
 
 export {
     HeaderWindows, HeaderMacOS, HeaderLinuxOS, AppNavigator, LeftSidebar, AppMusicPlayer, FSMusicPlayer,
@@ -45,5 +46,5 @@ export {
     NotifyBottomRight, PropertiesModal, LargeResizableCover,
     CreatePlaylistModal, EditPlaylistModal, AddSongToPlaylistModal, LoaderAnimated,
     AirplayCastModal, AddSongsToPlaylistModal, MusicPopOver, DeletePlaylistModal,
-    DeleteButton
+    DeleteButton, DeleteSongFromPlaylistModal
 }

--- a/muzik-offline/src/interface/components/index.ts
+++ b/muzik-offline/src/interface/components/index.ts
@@ -18,7 +18,6 @@ import AppNavigator from './buttons/AppNavigator';
 import GeneralContextMenu from './context_menu/GeneralContextMenu';
 import SearchNavigator from './buttons/SearchNavigator';
 import DirectoriesModal from "./modals/DirectoriesModal";
-import { ShowInfoButton } from './context_menu/ContextMenuButtons';
 import NotifyBottomRight from './toasts/NotifyBottomRight';
 import PropertiesModal from './modals/PropertiesModal';
 import LargeResizableCover from './cards/LargeResizableCover';
@@ -26,12 +25,14 @@ import CreatePlaylistModal from './modals/CreatePlaylistModal';
 import EditPlaylistModal from './modals/EditPlaylistModal';
 import { PlayButton, PlayNextButton, PlayLaterButton, 
     ShowArtistButton, AddToPlaylistButton, ShowGenreButton, 
-    ShowPlaylistButton, ShowAlbumButton } from './context_menu/ContextMenuButtons';
+    ShowPlaylistButton, ShowAlbumButton, ShowInfoButton, 
+    DeleteButton } from './context_menu/ContextMenuButtons';
 import AddSongToPlaylistModal from "./modals/AddSongToPlaylistModal";
 import LoaderAnimated from './loader/LoaderAnimated';
 import AirplayCastModal from './modals/AirplayCastModal';
 import AddSongsToPlaylistModal from './modals/AddSongsToPlaylistModal';
 import MusicPopOver from "./popover/MusicPopOver";
+import DeletePlaylistModal from './modals/DeletePlaylistModal';
 
 export {
     HeaderWindows, HeaderMacOS, HeaderLinuxOS, AppNavigator, LeftSidebar, AppMusicPlayer, FSMusicPlayer,
@@ -43,5 +44,6 @@ export {
     ShowAlbumButton, SearchNavigator, DirectoriesModal, ShowInfoButton,
     NotifyBottomRight, PropertiesModal, LargeResizableCover,
     CreatePlaylistModal, EditPlaylistModal, AddSongToPlaylistModal, LoaderAnimated,
-    AirplayCastModal, AddSongsToPlaylistModal, MusicPopOver
+    AirplayCastModal, AddSongsToPlaylistModal, MusicPopOver, DeletePlaylistModal,
+    DeleteButton
 }

--- a/muzik-offline/src/interface/components/modals/CreatePlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/CreatePlaylistModal.tsx
@@ -62,6 +62,10 @@ const CreatePlaylistModal : FunctionComponent<CreatePlaylistModalProps> = (props
 
     async function createPlaylistAndCloseModal(){
         const PLobj = playlistObj;
+        if(PLobj.title === ""){
+            setToast({title: "Playlist title", message: "Playlist title cannot be empty", type: toastType.warning, timeout: 3000});
+            return;
+        }
         PLobj.dateCreated = new Date().toLocaleDateString();
         PLobj.dateEdited = new Date().toLocaleDateString();
         //set key of PLobj as the last key in the database + 1
@@ -109,8 +113,9 @@ const CreatePlaylistModal : FunctionComponent<CreatePlaylistModalProps> = (props
                     </motion.label>
                 </div>
                 <h3>Playlist name</h3>
-                <input type="text" value={playlistObj.title} onChange={(e) => setPlaylistObj({ ... playlistObj, title : e.target.value})}/>
+                <input type="text" placeholder="enter playlist name here" value={playlistObj.title} onChange={(e) => setPlaylistObj({ ... playlistObj, title : e.target.value})}/>
                 <motion.div className="create_playlist" whileTap={{scale: 0.98}} onClick={createPlaylistAndCloseModal}>create playlist</motion.div>
+                <motion.div className="cancel_creation" whileTap={{scale: 0.98}} onClick={props.closeModal}>cancel</motion.div>
             </motion.div>
         </div>
     )

--- a/muzik-offline/src/interface/components/modals/DeletePlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/DeletePlaylistModal.tsx
@@ -2,6 +2,7 @@ import { modal_variants } from '@content/index';
 import { motion } from 'framer-motion';
 import { FunctionComponent } from 'react';
 import "@styles/components/modals/DeletePlaylistModal.scss";
+import { AlertTriangle } from '@assets/icons';
 
 type DeletePlaylistModalProps = {
     title: string;
@@ -17,17 +18,19 @@ const DeletePlaylistModal: FunctionComponent<DeletePlaylistModalProps> = (props:
                 animate={props.isOpen ? "open" : "closed"}
                 variants={modal_variants}
                 className="confirm_deletion_modal">
-                    <div className="modal_container">
-                        <h3>Are you sure you want to delete {props.title}?</h3>
-                        <div className="modal_buttons">
-                            <motion.div whileTap={{scale: 0.95}} className="cancel_button" onClick={() => props.closeModal(false)}>
-                                <h4>cancel</h4>
-                            </motion.div>
-                            <motion.div whileTap={{scale: 0.95}} className="delete_button" onClick={() => props.closeModal(true)}>
-                                <h4>delete</h4>
-                            </motion.div>
+                        <div className="covers">
+                            <div className="first_cover "/>
+                            <div className="second_cover">
+                                <AlertTriangle />
+                            </div>
                         </div>
-                    </div>
+                        <h3>Are you sure you want to delete {props.title}?</h3>
+                        <motion.div whileTap={{scale: 0.95}} className="delete_button" onClick={() => props.closeModal(true)}>
+                            <h4>delete</h4>
+                        </motion.div>
+                        <motion.div whileTap={{scale: 0.95}} className="cancel_button" onClick={() => props.closeModal(false)}>
+                            <h4>cancel</h4>
+                        </motion.div>
             </motion.div>
         </div>
     )

--- a/muzik-offline/src/interface/components/modals/DeletePlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/DeletePlaylistModal.tsx
@@ -1,0 +1,36 @@
+import { modal_variants } from '@content/index';
+import { motion } from 'framer-motion';
+import { FunctionComponent } from 'react';
+import "@styles/components/modals/DeletePlaylistModal.scss";
+
+type DeletePlaylistModalProps = {
+    title: string;
+    isOpen: boolean;
+    closeModal: (deletePlaylist: boolean) => void;
+}
+
+const DeletePlaylistModal: FunctionComponent<DeletePlaylistModalProps> = (props: DeletePlaylistModalProps) => {
+    return (
+        <div className={"DeletePlaylistModal" + (props.isOpen ? " DeletePlaylistModal-visible" : "")} onClick={
+            (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {if(e.target === e.currentTarget)props.closeModal(false)}}>
+            <motion.div 
+                animate={props.isOpen ? "open" : "closed"}
+                variants={modal_variants}
+                className="confirm_deletion_modal">
+                    <div className="modal_container">
+                        <h3>Are you sure you want to delete {props.title}?</h3>
+                        <div className="modal_buttons">
+                            <motion.div whileTap={{scale: 0.95}} className="cancel_button" onClick={() => props.closeModal(false)}>
+                                <h4>cancel</h4>
+                            </motion.div>
+                            <motion.div whileTap={{scale: 0.95}} className="delete_button" onClick={() => props.closeModal(true)}>
+                                <h4>delete</h4>
+                            </motion.div>
+                        </div>
+                    </div>
+            </motion.div>
+        </div>
+    )
+}
+
+export default DeletePlaylistModal

--- a/muzik-offline/src/interface/components/modals/DeleteSongFromPlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/DeleteSongFromPlaylistModal.tsx
@@ -1,18 +1,18 @@
-import { modal_variants } from '@content/index';
-import { motion } from 'framer-motion';
-import { FunctionComponent } from 'react';
-import "@styles/components/modals/DeletePlaylistModal.scss";
-import { AlertTriangle } from '@assets/icons';
+import { AlertTriangle } from "@assets/icons";
+import { modal_variants } from "@content/index";
+import { motion } from "framer-motion";
+import { FunctionComponent } from "react";
+import "@styles/components/modals/DeleteSongFromPlaylistModal.scss";
 
-type DeletePlaylistModalProps = {
+type DeleteSongFromPlaylistModalProps = {
     title: string;
     isOpen: boolean;
-    closeModal: (deletePlaylist: boolean) => void;
+    closeModal: (deleteSong: boolean) => void;
 }
 
-const DeletePlaylistModal: FunctionComponent<DeletePlaylistModalProps> = (props: DeletePlaylistModalProps) => {
+const DeleteSongFromPlaylistModal: FunctionComponent<DeleteSongFromPlaylistModalProps> = (props: DeleteSongFromPlaylistModalProps) => {
     return (
-        <div className={"DeletePlaylistModal" + (props.isOpen ? " DeletePlaylistModal-visible" : "")} onClick={
+        <div className={"DeleteSongFromPlaylistModal" + (props.isOpen ? " DeleteSongFromPlaylistModal-visible" : "")} onClick={
             (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {if(e.target === e.currentTarget)props.closeModal(false)}}>
             <motion.div 
                 animate={props.isOpen ? "open" : "closed"}
@@ -36,4 +36,4 @@ const DeletePlaylistModal: FunctionComponent<DeletePlaylistModalProps> = (props:
     )
 }
 
-export default DeletePlaylistModal
+export default DeleteSongFromPlaylistModal

--- a/muzik-offline/src/interface/components/modals/EditPlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/EditPlaylistModal.tsx
@@ -9,6 +9,8 @@ import { useToastStore } from 'store';
 import { getRandomCover } from 'utils';
 import { AppLogo } from '@assets/logos';
 import { modal_variants } from '@content/index';
+import { DeletePlaylistModal } from '@components/index';
+import { useNavigate } from "react-router-dom";
 
 type EditPlaylistModalProps = {
     playlistobj: playlist;
@@ -18,6 +20,8 @@ type EditPlaylistModalProps = {
 
 const EditPlaylistModal: FunctionComponent<EditPlaylistModalProps> = (props: EditPlaylistModalProps) => {
     const [playlistObj, setPlaylistObj] = useState<playlist>(props.playlistobj);
+    const [deletePlaylistModal, setDeletePlaylistModal] = useState<boolean>(false);
+    const navigate = useNavigate();
     const [isloading, setIsLoading] = useState<boolean>(false);
     const { setToast } = useToastStore((state) => { return { setToast: state.setToast }; });
 
@@ -71,9 +75,21 @@ const EditPlaylistModal: FunctionComponent<EditPlaylistModalProps> = (props: Edi
         props.closeModal();
     }
 
+    async function shouldDeletePlaylist(deletePlaylist: boolean){
+        if(deletePlaylist){
+            await local_playlists_db.playlists.delete(playlistObj.key);
+            //navigate to playlist page
+            navigate("/AllPlaylists");
+        }
+        else{
+            setDeletePlaylistModal(false);
+        }
+    }
+
     useEffect(() => {   
         setPlaylistObj(props.playlistobj);
         setIsLoading(false);
+        setDeletePlaylistModal(false);
     }, [props.isOpen])
 
     return (
@@ -110,10 +126,10 @@ const EditPlaylistModal: FunctionComponent<EditPlaylistModalProps> = (props: Edi
                 <h3>Playlist name</h3>
                 <input type="text" value={playlistObj.title} onChange={(e) => setPlaylistObj({ ... playlistObj, title : e.target.value})}/>
                 <motion.div className="edit_playlist" whileTap={{scale: 0.98}} onClick={savePlaylistAndCloseModal}>save changes</motion.div>
-                <motion.div className="delete_playlist" whileTap={{scale: 0.98}} onClick={props.closeModal}>delete playlist</motion.div>
+                <motion.div className="delete_playlist" whileTap={{scale: 0.98}} onClick={() => setDeletePlaylistModal(true)}>delete playlist</motion.div>
             </motion.div>
 
-            
+            <DeletePlaylistModal title={playlistObj.title} isOpen={deletePlaylistModal} closeModal={shouldDeletePlaylist}/>
         </div>
     )
 }

--- a/muzik-offline/src/interface/components/modals/EditPlaylistModal.tsx
+++ b/muzik-offline/src/interface/components/modals/EditPlaylistModal.tsx
@@ -110,7 +110,10 @@ const EditPlaylistModal: FunctionComponent<EditPlaylistModalProps> = (props: Edi
                 <h3>Playlist name</h3>
                 <input type="text" value={playlistObj.title} onChange={(e) => setPlaylistObj({ ... playlistObj, title : e.target.value})}/>
                 <motion.div className="edit_playlist" whileTap={{scale: 0.98}} onClick={savePlaylistAndCloseModal}>save changes</motion.div>
+                <motion.div className="delete_playlist" whileTap={{scale: 0.98}} onClick={props.closeModal}>delete playlist</motion.div>
             </motion.div>
+
+            
         </div>
     )
 }

--- a/muzik-offline/src/interface/components/toasts/NotifyBottomRight.tsx
+++ b/muzik-offline/src/interface/components/toasts/NotifyBottomRight.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion';
 import "@styles/components/toasts/NotifyBottomRight.scss";
 import { toast } from 'types';
-import { CheckGreen, Cross, CrossRed, InformationCircleContained, InformationCircleContainedBlue, InformationCircleContainedOrange } from '@assets/icons';
+import { CheckGreen, Cross, CrossRed, InformationCircleContained, InformationCircleContainedBlue, AlertTriangle } from '@assets/icons';
 import { useToastStore } from 'store';
 
 const variants={
@@ -20,7 +20,7 @@ const NotifyBottomRight = () => {
         else if(toast_d.type === "error")return CrossRed;
         else if(toast_d.type === "info")return InformationCircleContainedBlue;
         else if(toast_d.type === "success")return CheckGreen;
-        else if(toast_d.type === "warning")return InformationCircleContainedOrange;
+        else if(toast_d.type === "warning")return AlertTriangle;
         else return InformationCircleContained;
     }
 

--- a/muzik-offline/src/interface/layouts/AboutSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AboutSettings.tsx
@@ -11,7 +11,7 @@ const AboutSettings = () => {
                 <App_logo />
             </div>
             <h3>Copyright 2024 muzik-apps. All rights reserved.</h3>
-            <h3>Version "0.3.1"</h3>
+            <h3>Version "0.4.0"</h3>
             <h3>
                 <motion.span whileTap={{scale: 0.98}} onClick={() => open("https://github.com/muzik-apps/muzik-offline")}>
                     muzik-offline

--- a/muzik-offline/src/interface/pages/AllPlaylists.tsx
+++ b/muzik-offline/src/interface/pages/AllPlaylists.tsx
@@ -127,6 +127,8 @@ const AllPlaylists = () => {
                 title={state.playlistMenuToOpen? state.playlistMenuToOpen.title : ""} 
                 values={{playlist: state.playlistMenuToOpen? state.playlistMenuToOpen.title : ""}}
                 closeModal={() => closePlaylistModal(dispatch)} />
+
+            {/*delete playlist modal */}
         </motion.div>
     )
 }

--- a/muzik-offline/src/interface/pages/AllPlaylists.tsx
+++ b/muzik-offline/src/interface/pages/AllPlaylists.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { useEffect, useReducer } from "react";
-import { DropDownMenuSmall, SquareTitleBox, GeneralContextMenu, CreatePlaylistModal, PropertiesModal, LoaderAnimated, AddSongsToPlaylistModal } from "@components/index";
+import { DropDownMenuSmall, SquareTitleBox, GeneralContextMenu, CreatePlaylistModal, PropertiesModal, LoaderAnimated, AddSongsToPlaylistModal, DeletePlaylistModal } from "@components/index";
 import { ChevronDown, Menu } from "@assets/icons";
 import "@styles/pages/AllPlaylists.scss";
 import { contextMenuButtons, contextMenuEnum } from '@muziktypes/index';
@@ -30,6 +30,7 @@ const AllPlaylists = () => {
         if(arg === contextMenuButtons.ShowInfo){ dispatch({ type: reducerType.SET_PROPERTIES_MODAL, payload: true}); }
         else if(arg == contextMenuButtons.ShowPlaylist && state.playlistMenuToOpen)navigateTo(state.playlistMenuToOpen.key);
         else if(arg === contextMenuButtons.AddToPlaylist){ dispatch({ type: reducerType.SET_PLAYLIST_MODAL, payload: true}); }
+        else if(arg === contextMenuButtons.Delete){ dispatch({ type: reducerType.SET_DELETE_MODAL, payload: true}); }
         else if(arg === contextMenuButtons.PlayNext && state.playlistMenuToOpen){ 
             addTheseSongsToPlayNext({playlist: state.playlistMenuToOpen.title});
             closeContextMenu(dispatch); 
@@ -55,7 +56,19 @@ const AllPlaylists = () => {
         });
     }
 
-    useEffect(() => { setList(); }, [state.sort, state.isCreatePlaylistModalOpen])
+    async function shouldDeletePlaylist(deletePlaylist: boolean){
+        if(deletePlaylist && state.playlistMenuToOpen){
+            await local_playlists_db.playlists.delete(state.playlistMenuToOpen.key);
+            dispatch({ type: reducerType.SET_DELETE_MODAL, payload: false});
+            dispatch({ type: reducerType.SET_PLAYLIST_MENU, payload: null});
+        }
+        else{
+            dispatch({ type: reducerType.SET_DELETE_MODAL, payload: false});
+            dispatch({ type: reducerType.SET_PLAYLIST_MENU, payload: null});
+        }
+    }
+
+    useEffect(() => { setList(); }, [state.sort, state.isCreatePlaylistModalOpen, state.isDeletePlayListModalOpen])
     
     return (
         <motion.div className="AllPlaylists"
@@ -127,8 +140,10 @@ const AllPlaylists = () => {
                 title={state.playlistMenuToOpen? state.playlistMenuToOpen.title : ""} 
                 values={{playlist: state.playlistMenuToOpen? state.playlistMenuToOpen.title : ""}}
                 closeModal={() => closePlaylistModal(dispatch)} />
-
-            {/*delete playlist modal */}
+            <DeletePlaylistModal 
+                isOpen={state.isDeletePlayListModalOpen} 
+                title={state.playlistMenuToOpen? state.playlistMenuToOpen.title : ""} 
+                closeModal={shouldDeletePlaylist} />
         </motion.div>
     )
 }

--- a/muzik-offline/src/interface/pages/PlaylistView.tsx
+++ b/muzik-offline/src/interface/pages/PlaylistView.tsx
@@ -195,7 +195,7 @@ const PlaylistView = () => {
                             xPos={state.co_ords.xPos} 
                             yPos={state.co_ords.yPos} 
                             title={state.songMenuToOpen.name}
-                            CMtype={contextMenuEnum.SongCM}
+                            CMtype={contextMenuEnum.PlaylistSongsCM}
                             chooseOption={chooseOption}/>
                     </div>
                 )

--- a/muzik-offline/src/interface/pages/PlaylistView.tsx
+++ b/muzik-offline/src/interface/pages/PlaylistView.tsx
@@ -1,5 +1,5 @@
 import { Edit, Play, Shuffle } from "@assets/icons";
-import { LargeResizableCover, RectangleSongBox, GeneralContextMenu, EditPlaylistModal, PropertiesModal, AddSongToPlaylistModal } from "@components/index";
+import { LargeResizableCover, RectangleSongBox, GeneralContextMenu, EditPlaylistModal, PropertiesModal, AddSongToPlaylistModal, DeleteSongFromPlaylistModal } from "@components/index";
 import { local_albums_db, local_playlists_db } from "@database/database";
 import { contextMenuButtons, contextMenuEnum } from "@muziktypes/index";
 import { motion } from "framer-motion";
@@ -30,6 +30,7 @@ const PlaylistView = () => {
     function chooseOption(arg: contextMenuButtons){
         if(arg === contextMenuButtons.ShowInfo){ dispatch({ type: reducerType.SET_PROPERTIES_MODAL, payload: true}); }
         else if(arg === contextMenuButtons.AddToPlaylist){ dispatch({ type: reducerType.SET_PLAYLIST_MODAL, payload: true}); }
+        else if(arg === contextMenuButtons.Delete){ dispatch({ type: reducerType.SET_DELETE_MODAL, payload: true}); }
         else if(arg === contextMenuButtons.PlayNext && state.songMenuToOpen){ 
             addThisSongToPlayNext([state.songMenuToOpen.id]);
             closeContextMenu(dispatch); 
@@ -116,6 +117,40 @@ const PlaylistView = () => {
             else if((ev.ctrlKey || ev.metaKey) && ev.shiftKey && (ev.key === "a" || ev.key === "A"))chooseOption(contextMenuButtons.AddToPlaylist);
             else if((ev.ctrlKey || ev.metaKey) && ev.shiftKey && (ev.key === "n" || ev.key === "N"))chooseOption(contextMenuButtons.PlayNext);
             else if((ev.ctrlKey || ev.metaKey) && ev.shiftKey && (ev.key === "l" || ev.key === "L"))chooseOption(contextMenuButtons.PlayLater);
+        }
+    }
+
+    async function shouldDeleteSong(deleteSong: boolean){
+        if(deleteSong && state.songMenuToOpen !== null){
+            //remove song from playlist path
+            const playlist_mt = state.playlist_metadata.playlist_data;
+            if(playlist_mt !== null){
+                const path_to_remove = state.songMenuToOpen.path;
+                const newTracks = playlist_mt.tracksPaths.filter((path) => path !== path_to_remove);
+                playlist_mt.tracksPaths = newTracks;
+                await local_playlists_db.playlists.update(playlist_mt.key, playlist_mt);
+                //remove song from song list
+                const id_to_remove = state.songMenuToOpen.id;
+                const newSongList = state.SongList.filter((song) => song.id !== id_to_remove);
+                //update the song list
+                setSongList(newSongList, dispatch);
+                //recalculate the playlist length
+                let acc = 0;
+                newSongList.map((curr) => { acc = acc + curr.duration_seconds});
+                //update the playlist metadata
+                dispatch({ type: reducerType.SET_PLAYLIST_METADATA, payload: {
+                    playlist_data: playlist_mt,
+                    song_count: newSongList.length,
+                    length: secondsToTimeFormat(acc)
+                    }
+                });
+            }
+            dispatch({ type: reducerType.SET_DELETE_MODAL, payload: false});
+            dispatch({ type: reducerType.SET_SONG_MENU, payload: null});
+        }
+        else{
+            dispatch({ type: reducerType.SET_DELETE_MODAL, payload: false});
+            dispatch({ type: reducerType.SET_SONG_MENU, payload: null});
         }
     }
 
@@ -206,6 +241,10 @@ const PlaylistView = () => {
                 isOpen={state.isEditingPlayListModalOpen} closeModal={closeModalAndResetData}/>
             <AddSongToPlaylistModal isOpen={state.isPlaylistModalOpen} songPath={state.songMenuToOpen ? state.songMenuToOpen.path : ""} closeModal={() => closePlaylistModal(dispatch)} />
             <PropertiesModal isOpen={state.isPropertiesModalOpen} song={state.songMenuToOpen ? state.songMenuToOpen : undefined} closeModal={() => closePropertiesModal(dispatch)} />
+            <DeleteSongFromPlaylistModal 
+                title={state.songMenuToOpen ? state.songMenuToOpen.name : ""} 
+                isOpen={state.isDeleteSongModalOpen} 
+                closeModal={shouldDeleteSong}/>
         </motion.div>
     )
 }

--- a/muzik-offline/src/interface/styles/components/context_menu/GeneralContextMenu.scss
+++ b/muzik-offline/src/interface/styles/components/context_menu/GeneralContextMenu.scss
@@ -15,7 +15,7 @@
     padding: 9px;
 
     .Play, .PlayNext, .PlayLater, .ShowArtist, .Add_to_playlist,
-    .Genre, .ShowPlaylist, .ShowAlbum, .ShowInfo{
+    .Genre, .ShowPlaylist, .ShowAlbum, .ShowInfo, .DeleteButton{
         display: flex;
         height: 34px;
         border-radius: 10px;
@@ -39,7 +39,7 @@
     }
 
     .Play:hover, .PlayNext:hover, .PlayLater:hover, .ShowArtist:hover, .Add_to_playlist:hover,
-    .Genre:hover, .ShowPlaylist:hover, .ShowAlbum:hover, .ShowInfo:hover{
+    .Genre:hover, .ShowPlaylist:hover, .ShowAlbum:hover, .ShowInfo:hover, .DeleteButton:hover{
         opacity: 0.8;
     }
 }

--- a/muzik-offline/src/interface/styles/components/modals/CreatePlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/CreatePlaylistModal.scss
@@ -16,7 +16,7 @@
     .modal{
         width: 300px;
         height: 350px;
-        padding: 20px;
+        padding: 13px;
         border: 1px solid $songs-container-border-col;
         background: var(--var-songs-container-bg-col);
         box-shadow: $box-shadow-10-10-25;
@@ -38,7 +38,7 @@
             .playlist_img{
                 width: 150px;
                 height: 150px;
-                border-radius: 40px;
+                border-radius: 35px;
                 overflow: hidden;
 
                 img{
@@ -71,23 +71,23 @@
 
         input[type="text"]{
             width: calc(100% - 8px);
-            height: 50px;
+            height: 27px;
             border: none;
             padding: 4px;
             outline: none;
             background: $btn-clickable;
-            border-radius: 16px;
+            border-radius: 13px;
             font-size: 22px;
             color: $white-900;
             margin-top: 2px;
         }
 
-        .create_playlist{
-            margin-top: 10px;
+        .create_playlist, .cancel_creation{
+            margin-top: 7px;
             width: 100%;
-            height: 50px;
-            background-color: $app-theme-col;
-            border-radius: 16px;
+            height: 35px;
+            background: $app-theme-col;
+            border-radius: 13px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -95,8 +95,13 @@
             color: $root-app-navigator-hover-col;
         }
 
-        .create_playlist:hover{
+        .create_playlist:hover, .cancel_creation:hover{
             opacity: 0.8;
+        }
+
+        .cancel_creation{
+            background: $on-hover-song;
+            color: $white-900;
         }
     }
 }

--- a/muzik-offline/src/interface/styles/components/modals/DeletePlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/DeletePlaylistModal.scss
@@ -1,0 +1,19 @@
+@import "../../constants/constants";
+
+.DeletePlaylistModal{
+    position: fixed;
+    width: 100vw;
+    height: 100vh;
+    top: 0;
+    left: 0;
+    background: $blur-element;
+    flex-direction: column;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: $z-index-9999;
+}
+
+.DeletePlaylistModal-visible{
+    display: flex;
+}

--- a/muzik-offline/src/interface/styles/components/modals/DeletePlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/DeletePlaylistModal.scss
@@ -12,6 +12,80 @@
     justify-content: center;
     align-items: center;
     z-index: $z-index-9999;
+
+    .confirm_deletion_modal{
+        width: 300px;
+        height: 203px;
+        padding: 13px;
+        border: 1px solid $songs-container-border-col;
+        background: var(--var-songs-container-bg-col);
+        box-shadow: $box-shadow-10-10-25;
+        backdrop-filter: var(--var-bg-blur-150);
+        -webkit-backdrop-filter: var(--var-bg-blur-150);
+        border-radius: 20px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+
+        .covers{
+            margin-top: 13px;
+            margin-left: 13px;
+            margin-bottom: 13px;
+            width: 24px;
+            height: 24px;
+            position: relative;
+            .first_cover, .second_cover{
+                width: 24px;
+                height: 24px;
+                flex-shrink: 0;
+                display: flex;
+                overflow: hidden;
+                justify-content: center;
+                align-items: center;
+                svg{
+                    width: 100%;
+                    height: 100%;
+                }
+            }
+    
+            .first_cover{
+                background: $orange-1000;
+                filter: $layer-blur-50;
+                -webkit-filter: $layer-blur-50;
+            }
+    
+            .second_cover{
+                margin-top: -24px;
+                position: absolute;
+            }
+        }
+
+        h3{
+            font-size: 20px;
+            margin-top: 0px;
+            margin-bottom: 20px;
+        }
+
+        .cancel_button, .delete_button{
+            margin-top: 7px;
+            width: 100%;
+            height: 35px;
+            border-radius: 13px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            color: $white-900;
+        }
+
+        .cancel_button:hover, .delete_button:hover{
+            opacity: 0.8;
+        }
+
+        .cancel_button{ background: $on-hover-song; }
+
+        .delete_button{ background: $red-900; }
+    }
 }
 
 .DeletePlaylistModal-visible{

--- a/muzik-offline/src/interface/styles/components/modals/DeleteSongFromPlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/DeleteSongFromPlaylistModal.scss
@@ -1,6 +1,6 @@
 @import "../../constants/constants";
 
-.DeletePlaylistModal{
+.DeleteSongFromPlaylistModal{
     position: fixed;
     width: 100vw;
     height: 100vh;
@@ -89,6 +89,6 @@
     }
 }
 
-.DeletePlaylistModal-visible{
+.DeleteSongFromPlaylistModal-visible{
     display: flex;
 }

--- a/muzik-offline/src/interface/styles/components/modals/EditPlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/EditPlaylistModal.scss
@@ -16,7 +16,7 @@
     .modal{
         width: 300px;
         height: 350px;
-        padding: 20px;
+        padding: 13px;
         border: 1px solid $songs-container-border-col;
         background: var(--var-songs-container-bg-col);
         box-shadow: $box-shadow-10-10-25;
@@ -38,7 +38,7 @@
             .playlist_img{
                 width: 150px;
                 height: 150px;
-                border-radius: 40px;
+                border-radius: 35px;
                 overflow: hidden;
                 display: flex;
                 align-items: center;
@@ -83,23 +83,23 @@
 
         input[type="text"]{
             width: calc(100% - 8px);
-            height: 50px;
+            height: 27px;
             border: none;
             padding: 4px;
             outline: none;
             background: $btn-clickable;
-            border-radius: 16px;
+            border-radius: 13px;
             font-size: 22px;
             color: $white-900;
             margin-top: 2px;
         }
 
-        .edit_playlist{
-            margin-top: 10px;
+        .edit_playlist, .delete_playlist{
+            margin-top: 7px;
             width: 100%;
-            height: 50px;
-            background-color: $app-theme-col;
-            border-radius: 16px;
+            height: 35px;
+            background: $app-theme-col;
+            border-radius: 13px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -107,8 +107,13 @@
             color: $root-app-navigator-hover-col;
         }
 
-        .edit_playlist:hover{
+        .edit_playlist:hover, .delete_playlist:hover{
             opacity: 0.8;
+        }
+
+        .delete_playlist{
+            background: $red-900;
+            color: $white-900;
         }
     }
 }

--- a/muzik-offline/src/interface/styles/components/modals/EditPlaylistModal.scss
+++ b/muzik-offline/src/interface/styles/components/modals/EditPlaylistModal.scss
@@ -112,8 +112,8 @@
         }
 
         .delete_playlist{
-            background: $red-900;
-            color: $white-900;
+            background: $on-hover-song;
+            color: $red-900;
         }
     }
 }

--- a/muzik-offline/src/store/reducerStore.ts
+++ b/muzik-offline/src/store/reducerStore.ts
@@ -219,6 +219,7 @@ export const PlaylistViewState: PlaylistViewInterface = {
     isEditingPlayListModalOpen: false,
     isPlaylistModalOpen: false,
     isPropertiesModalOpen: false,
+    isDeleteSongModalOpen: false,
     resizeHeader: false,
 };
 
@@ -233,6 +234,7 @@ export const playlistViewReducer = (state: PlaylistViewInterface, action: Action
         case reducerType.SET_EDIT_PLAYLIST_MODAL: return { ...state, isEditingPlayListModalOpen: action.payload };
         case reducerType.SET_PLAYLIST_MODAL: return { ...state, isPlaylistModalOpen: action.payload };
         case reducerType.SET_PROPERTIES_MODAL: return { ...state, isPropertiesModalOpen: action.payload };
+        case reducerType.SET_DELETE_MODAL: return { ...state, isDeleteSongModalOpen: action.payload };
         case reducerType.SET_RESIZE_HEADER: return { ...state, resizeHeader: action.payload };
         default: return state;
     }

--- a/muzik-offline/src/store/reducerStore.ts
+++ b/muzik-offline/src/store/reducerStore.ts
@@ -249,6 +249,7 @@ export const AllPlaylistsState: AllPlaylistsInterface = {
     isPlaylistModalOpen: false,
     isCreatePlaylistModalOpen: false,
     isPropertiesModalOpen: false,
+    isDeletePlayListModalOpen: false
 };
 
 export const allPlaylistsReducer = (state: AllPlaylistsInterface, action: Action) => {
@@ -263,6 +264,7 @@ export const allPlaylistsReducer = (state: AllPlaylistsInterface, action: Action
         case reducerType.SET_PLAYLIST_MODAL: return { ...state, isPlaylistModalOpen: action.payload };
         case reducerType.SET_PROPERTIES_MODAL: return { ...state, isPropertiesModalOpen: action.payload };
         case reducerType.SET_CREATE_PLAYLIST_MODAL: return { ...state, isCreatePlaylistModalOpen: action.payload };
+        case reducerType.SET_DELETE_MODAL: return { ...state, isDeletePlayListModalOpen: action.payload };
         default: return state;
     }
 };

--- a/muzik-offline/src/store/reducerTypes.ts
+++ b/muzik-offline/src/store/reducerTypes.ts
@@ -185,6 +185,7 @@ export interface PlaylistViewInterface{
     isEditingPlayListModalOpen: boolean,
     isPlaylistModalOpen: boolean,
     isPropertiesModalOpen: boolean,
+    isDeleteSongModalOpen: boolean,
     resizeHeader: boolean;
 }
 

--- a/muzik-offline/src/store/reducerTypes.ts
+++ b/muzik-offline/src/store/reducerTypes.ts
@@ -12,6 +12,7 @@ export enum reducerType {
     SET_EDIT_PLAYLIST_MODAL = "SET_EDIT_PLAYLIST_MODAL",
     SET_CREATE_PLAYLIST_MODAL = "SET_CREATE_PLAYLIST_MODAL",
     SET_PROPERTIES_MODAL = "SET_PROPERTIES_MODAL",
+    SET_DELETE_MODAL = "SET_DELETE_MODAL",
     SET_RESIZE_HEADER = "SET_RESIZE_HEADER",
     SET_SONG_LIST = "SET_SONG_LIST",
     SET_SONG_MENU = "SET_SONG_MENU",
@@ -43,6 +44,7 @@ export type Action =
     | { type: reducerType.SET_EDIT_PLAYLIST_MODAL; payload: boolean }
     | { type: reducerType.SET_CREATE_PLAYLIST_MODAL; payload: boolean }
     | { type: reducerType.SET_PROPERTIES_MODAL; payload: boolean }
+    | { type: reducerType.SET_DELETE_MODAL; payload: boolean }
     | { type: reducerType.SET_RESIZE_HEADER; payload: boolean }
     | { type: reducerType.SET_SONG_LIST; payload: Song[] }
     | { type: reducerType.SET_SONG_MENU; payload: Song | null }
@@ -170,6 +172,7 @@ export interface AllPlaylistsInterface{
     isPlaylistModalOpen: boolean,
     isCreatePlaylistModalOpen: boolean,
     isPropertiesModalOpen: boolean,
+    isDeletePlayListModalOpen: boolean
 }
 
 export interface PlaylistViewInterface{

--- a/muzik-offline/src/types/index.ts
+++ b/muzik-offline/src/types/index.ts
@@ -28,7 +28,8 @@ export enum contextMenuEnum{
     GenreCM = "GenreCM",
     PlaylistCM = "PlaylistCM",
     SongCM = "SongCM",
-    AlbumCM = "AlbumCM"
+    AlbumCM = "AlbumCM",
+    PlaylistSongsCM = "PlaylistSongsCM"
 }
 
 export enum contextMenuButtons{
@@ -41,6 +42,7 @@ export enum contextMenuButtons{
     ShowPlaylist = "ShowPlaylist",
     ShowAlbum = "ShowAlbum",
     ShowInfo = "ShowInfo",
+    Delete = "Delete",
 }
 
 export enum toastType{


### PR DESCRIPTION
# Redesigning how the playlist page works
1. Updated the modal for creating and editing a playlist to be more visually appealing and be easier to use.
2. Added a confirmation dialogue for a user to confirm deleting a song from a playlist or deleting a playlist.
3. Added some new app icons for the playlist pages