### PR TITLE
Recursive path scan

### DIFF
--- a/muzik-offline/package-lock.json
+++ b/muzik-offline/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muzik-offline",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muzik-offline",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@hello-pangea/dnd": "^16.5.0",
         "@tauri-apps/api": "2.1.1",

--- a/muzik-offline/package.json
+++ b/muzik-offline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "muzik-offline",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -2941,7 +2941,7 @@ dependencies = [
 
 [[package]]
 name = "muzik-offline"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.21.7",
  "cocoa 0.26.0",

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -2970,6 +2970,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tokio",
  "uuid 1.11.0",
+ "walkdir",
  "warp",
  "windows 0.44.0",
 ]

--- a/muzik-offline/src-tauri/Cargo.lock
+++ b/muzik-offline/src-tauri/Cargo.lock
@@ -1496,6 +1496,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1585,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2948,6 +2964,7 @@ dependencies = [
  "dirs 5.0.1",
  "discord-rich-presence",
  "dotenv",
+ "futures",
  "id3",
  "image",
  "kira",

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "muzik-offline"
-version = "0.6.1"
+version = "0.6.2"
 description = "A desktop music player for listening to music offline."
 authors = ["Michael"]
 license = "MIT"

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ tauri-plugin-os = "2"
 printpdf = "0.7.0"
 tabled = "0.16.0"
 walkdir = "2.5.0"
+futures = "0.3.31"
 
 [dependencies.uuid]
 version = "1.11.0"

--- a/muzik-offline/src-tauri/Cargo.toml
+++ b/muzik-offline/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-http = "2"
 tauri-plugin-os = "2"
 printpdf = "0.7.0"
 tabled = "0.16.0"
+walkdir = "2.5.0"
 
 [dependencies.uuid]
 version = "1.11.0"

--- a/muzik-offline/src-tauri/src/commands/metadata_edit.rs
+++ b/muzik-offline/src-tauri/src/commands/metadata_edit.rs
@@ -25,6 +25,7 @@ pub fn edit_song_metadata(
     //convert song_metadata to Song using serde_json
     match serde_json::from_str::<Song>(&song_metadata) {
         Ok(mut song) => {
+            let db_manager = Arc::clone(&db_manager);
             if let Ok(cov_as_vec) = edit_metadata_id3(&song_path, &song, &has_changed_cover, &cover)
             {
                 if has_changed_cover == true {

--- a/muzik-offline/src-tauri/src/commands/refresh_paths_at_start.rs
+++ b/muzik-offline/src-tauri/src/commands/refresh_paths_at_start.rs
@@ -17,18 +17,20 @@ pub async fn refresh_paths(
     db_manager: State<'_, Arc<Mutex<DbManager>>>,
     paths_as_json_array: String,
     compress_image_option: bool,
+    max_depth: usize,
 ) -> Result<String, String> {
     let paths_as_vec = decode_directories(&paths_as_json_array);
 
-    let mut song_id: i32 = 0;
+    let song_id = Arc::new(Mutex::new(0));
     let mut new_songs_detected = 0;
     for path in &paths_as_vec {
         new_songs_detected += get_songs_in_path(
             db_manager.clone(),
             &path,
-            &mut song_id,
-            &compress_image_option,
+            song_id.clone(),
+            compress_image_option,
             true,
+            max_depth
         )
         .await;
     }

--- a/muzik-offline/src-tauri/src/database/db_api.rs
+++ b/muzik-offline/src-tauri/src/database/db_api.rs
@@ -545,10 +545,11 @@ pub async fn create_playlist_cover(
         }
     };
 
+    let dbm = Arc::clone(&db_manager);
     if compress_image {
         match resize_and_compress_image(&image_as_bytes, &250) {
             Some(thumbnail) => {
-                match insert_into_covers_tree(db_manager.clone(), thumbnail, &playlist_name) {
+                match insert_into_covers_tree(dbm, thumbnail, &playlist_name) {
                     uuid => {
                         return Ok(uuid.to_string());
                     }
@@ -559,7 +560,7 @@ pub async fn create_playlist_cover(
             }
         }
     } else {
-        match insert_into_covers_tree(db_manager.clone(), image_as_bytes, &playlist_name) {
+        match insert_into_covers_tree(dbm, image_as_bytes, &playlist_name) {
             uuid => {
                 return Ok(uuid.to_string());
             }
@@ -869,7 +870,7 @@ pub fn get_song_paths(db_manager: State<'_, Arc<Mutex<DbManager>>>) -> HashMap<S
 // new refactored insertion functions
 
 // this function can also overwrite the previous song with the same id
-pub fn insert_song_into_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song: &Song) {
+pub fn insert_song_into_tree(db_manager: Arc<Mutex<DbManager>>, song: &Song) {
     match db_manager.lock() {
         Ok(dbm) => {
             let song_tree = match dbm.song_tree.write() {
@@ -893,7 +894,7 @@ pub fn insert_song_into_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song:
     }
 }
 
-pub fn song_exists_in_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, path: &str) -> bool {
+pub fn song_exists_in_tree(db_manager: Arc<Mutex<DbManager>>, path: &str) -> bool {
     match db_manager.lock() {
         Ok(dbm) => {
             let song_tree = match dbm.song_tree.read() {
@@ -986,7 +987,7 @@ pub fn delete_song_from_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, path:
     }
 }
 
-pub fn insert_into_album_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song: &Song) {
+pub fn insert_into_album_tree(db_manager: Arc<Mutex<DbManager>>, song: &Song) {
     match db_manager.lock() {
         Ok(dbm) => {
             let album_tree = match dbm.album_tree.write() {
@@ -1065,7 +1066,7 @@ pub fn insert_into_album_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song
     }
 }
 
-pub fn insert_into_artist_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song: &Song) {
+pub fn insert_into_artist_tree(db_manager: Arc<Mutex<DbManager>>, song: &Song) {
     match db_manager.lock() {
         Ok(dbm) => {
             let artist_tree = match dbm.artist_tree.write() {
@@ -1147,7 +1148,7 @@ pub fn insert_into_artist_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, son
     }
 }
 
-pub fn insert_into_genre_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song: &Song) {
+pub fn insert_into_genre_tree(db_manager: Arc<Mutex<DbManager>>, song: &Song) {
     match db_manager.lock() {
         Ok(dbm) => {
             let genre_tree = match dbm.genre_tree.write() {
@@ -1227,7 +1228,7 @@ pub fn insert_into_genre_tree(db_manager: State<'_, Arc<Mutex<DbManager>>>, song
 }
 
 pub fn insert_into_covers_tree(
-    db_manager: State<'_, Arc<Mutex<DbManager>>>,
+    db_manager: Arc<Mutex<DbManager>>,
     cover: Vec<u8>,
     song_path: &String,
 ) -> uuid::Uuid {

--- a/muzik-offline/src-tauri/tauri.conf.json
+++ b/muzik-offline/src-tauri/tauri.conf.json
@@ -36,7 +36,7 @@
   },
   "productName": "muzik-offline",
   "mainBinaryName": "muzik-offline",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.muzik-offline.dev",
   "plugins": {},
   "app": {

--- a/muzik-offline/src-tauri/tauri.linux.conf.json
+++ b/muzik-offline/src-tauri/tauri.linux.conf.json
@@ -43,7 +43,7 @@
   },
   "productName": "muzik-offline",
   "mainBinaryName": "muzik-offline",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.muzik-offline.dev",
   "plugins": {},
   "app": {

--- a/muzik-offline/src-tauri/tauri.macos.conf.json
+++ b/muzik-offline/src-tauri/tauri.macos.conf.json
@@ -36,7 +36,7 @@
   },
   "productName": "muzik-offline",
   "mainBinaryName": "muzik-offline",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.muzik-offline.dev",
   "plugins": {},
   "app": {

--- a/muzik-offline/src-tauri/tauri.windows.conf.json
+++ b/muzik-offline/src-tauri/tauri.windows.conf.json
@@ -36,7 +36,7 @@
   },
   "productName": "muzik-offline",
   "mainBinaryName": "muzik-offline",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.muzik-offline.dev",
   "plugins": {},
   "app": {

--- a/muzik-offline/src/database/saved_object.ts
+++ b/muzik-offline/src/database/saved_object.ts
@@ -19,6 +19,7 @@ export interface SavedObject{
     SongLengthORremaining: string,
     AlwaysRoundedCornersWindows: string,
     AutoStartApp: string,
+    DirectoryScanningDepth: number
 }
 
 export const emptySavedObject: SavedObject = {
@@ -39,5 +40,6 @@ export const emptySavedObject: SavedObject = {
     SeekStepAmount: "10",
     SongLengthORremaining: "song length",
     AlwaysRoundedCornersWindows: "No",
-    AutoStartApp: "No"
+    AutoStartApp: "No",
+    DirectoryScanningDepth: 1
 }

--- a/muzik-offline/src/interface/App/App.tsx
+++ b/muzik-offline/src/interface/App/App.tsx
@@ -106,7 +106,11 @@ const App = () => {
       }
       setFirstRun(false);
     }*/
-    invoke("refresh_paths", { pathsAsJsonArray: JSON.stringify(paths), compressImageOption: local_store.CompressImage === "Yes" ? true : false })
+    invoke("refresh_paths", { 
+      athsAsJsonArray: JSON.stringify(paths), 
+      compressImageOption: local_store.CompressImage === "Yes" ? true : false,
+      maxDepth: local_store.DirectoryScanningDepth
+    })
     .then(async(response: any) => {
       if(response === "No new songs detected")return;
       const res = await fetch_library(false);

--- a/muzik-offline/src/interface/layouts/AboutSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AboutSettings.tsx
@@ -11,7 +11,7 @@ const AboutSettings = () => {
                 <App_logo />
             </div>
             <h3>Copyright 2024 muzik-apps. All rights reserved.</h3>
-            <h3>Version "0.6.1"</h3>
+            <h3>Version "0.6.2"</h3>
             <h3>
                 <motion.span whileTap={{scale: 0.98}} onClick={() => open("https://github.com/muzik-apps/muzik-offline")}>
                     muzik-offline

--- a/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
+++ b/muzik-offline/src/interface/layouts/AdvancedSettings.tsx
@@ -118,23 +118,37 @@ const AdvancedSettings = () => {
                         </div>
                     </div>)
                 }
-                {/*
                 <div className="setting">
-                    <h3>Create a backup of your library(may take some time)</h3>
-                    <div className="setting_dropdown">
-                        <motion.div className="setting_dropdown" whileTap={{scale: 0.98}} whileHover={{scale: 1.03}} onClick={() => {}}>
-                            <h4>Create backup</h4>
-                        </motion.div>
-                    </div>
+                    <h3>Max folder depth to scan between 1 and 50(Note larger values will take longer)</h3>
+                    <input type="number" value={local_store.DirectoryScanningDepth} onChange={(e) => {
+                        // clamp the value to 1-50
+                        if(e.target.value === "") e.target.value = "0";
+                        else if(parseInt(e.target.value) < 1) e.target.value = "1";
+                        else if(parseInt(e.target.value) > 50) e.target.value = "50";
+                        else if(e.target.value.startsWith("0")) e.target.value = e.target.value.slice(1);
+                        let temp: SavedObject = local_store;
+                        temp.DirectoryScanningDepth = parseInt(e.target.value);
+                        setStore(temp);
+                    }}/>
                 </div>
-                <div className="setting">
-                    <h3>Import library backup(may take some time)</h3>
-                    <div className="setting_dropdown">
-                        <motion.div className="setting_dropdown" whileTap={{scale: 0.98}} whileHover={{scale: 1.03}} onClick={() => {}}>
-                            <h4>Import backup</h4>
-                        </motion.div>
+                {/*
+                    <div className="setting">
+                        <h3>Create a backup of your library(may take some time)</h3>
+                        <div className="setting_dropdown">
+                            <motion.div className="setting_dropdown" whileTap={{scale: 0.98}} whileHover={{scale: 1.03}} onClick={() => {}}>
+                                <h4>Create backup</h4>
+                            </motion.div>
+                        </div>
                     </div>
-                </div>*/}
+                    <div className="setting">
+                        <h3>Import library backup(may take some time)</h3>
+                        <div className="setting_dropdown">
+                            <motion.div className="setting_dropdown" whileTap={{scale: 0.98}} whileHover={{scale: 1.03}} onClick={() => {}}>
+                                <h4>Import backup</h4>
+                            </motion.div>
+                        </div>
+                    </div>
+                */}
             </div>
         </div>
     )

--- a/muzik-offline/src/interface/layouts/MusicFoldersSettings.tsx
+++ b/muzik-offline/src/interface/layouts/MusicFoldersSettings.tsx
@@ -24,7 +24,11 @@ const MusicFoldersSettings: FunctionComponent<MusicFoldersSettingsProps> = (prop
     const [directory, setDirectory] = useState<string>("");
 
     function reloadSongs(){
-        invoke("get_all_songs", { pathsAsJsonArray: JSON.stringify(Array.from(currentDir)), compressImageOption: local_store.CompressImage === "Yes" ? true : false })
+        invoke("get_all_songs", { 
+            pathsAsJsonArray: JSON.stringify(Array.from(currentDir)), 
+            compressImageOption: local_store.CompressImage === "Yes" ? true : false,
+            maxDepth: local_store.DirectoryScanningDepth
+        })
         .then(async() => {
                 setDir({Dir: currentDir});
                 await local_songs_db.songs.clear();

--- a/muzik-offline/src/interface/styles/layouts/AdvancedSettings.scss
+++ b/muzik-offline/src/interface/styles/layouts/AdvancedSettings.scss
@@ -74,6 +74,25 @@
                 top: 55px;
                 z-index: $z-index-9250;
             }
+
+            input[type="number"]{
+                width: 156px;
+                height: 40px;
+                border-radius: 10px;
+                background: $gray-stroke-20;
+                border: none;
+                outline: none;
+                padding: 0px 0px 0px 0px;
+                padding-left: 4px;
+                padding-right: 4px;
+                font-size: 13px;
+                color: $white-900;
+                font-family: 'inter-italic-regular', sans-serif;
+                font-style: italic;
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+            }
         }
     }
 }

--- a/muzik-offline/src/utils/index.ts
+++ b/muzik-offline/src/utils/index.ts
@@ -293,7 +293,11 @@ export async function reloadLibrary(paths: string[]){
     });
     const local_store = useSavedObjectStore.getState().local_store;
 
-    invoke("get_all_songs", { pathsAsJsonArray: JSON.stringify(Array.from(dirs)), compressImageOption: local_store.CompressImage === "Yes" ? true : false })
+    invoke("get_all_songs", { 
+        pathsAsJsonArray: JSON.stringify(Array.from(dirs)), 
+        compressImageOption: local_store.CompressImage === "Yes" ? true : false,
+        maxDepth: local_store.DirectoryScanningDepth
+    })
     .then(async() => {
         useDirStore.getState().setDir({Dir: dirs});
         await local_songs_db.songs.clear();


### PR DESCRIPTION
## Describe your changes
This PR introduces a new feature in the advanced settings that allows users to specify the depth for file scanning. The depth level determines how many directory levels the scanner will traverse before stopping.

### Key details:
- Level 1: The scanner only inspects files in the given folder without looking into subfolders.
- Level 2: The scanner inspects the given folder and its immediate subfolders.
- Level 3: The scanner goes one level deeper, inspecting the given folder, its subfolders, and their subfolders.
- The feature uses a breadth-first search approach to traverse the directory tree based on the specified depth.
Example:
Suppose the folder structure is as follows:

```
C:\folder_a
├── file_1.txt
├── folder_aa
│   ├── file_2.txt
│   ├── folder_aaa
│   │   ├── file_3.txt
│   │   └── folder_aaaa
│   └── folder_aab
├── folder_ab
```
- With Level 1, only C:\folder_a is scanned, returning file_1.txt.
- With Level 2, folder_aa and folder_ab are also scanned, returning file_2.txt and the contents of folder_ab.
- With Level 3, the scanner includes folder_aaa and folder_aab, returning file_3.txt and the files in those subfolders.
- With Level 4 or higher, deeper levels such as folder_aaaa will also be scanned.

## Issue ticket number and link
#70 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
***This update introduces customizable file scan depth, enabling more precise control over directory traversal during file scanning.***